### PR TITLE
Implement platform-determined path-name lookup for FFI

### DIFF
--- a/src/consts.js
+++ b/src/consts.js
@@ -1,0 +1,26 @@
+
+const os = require('os');
+
+const TAG_TYPE_DNS = 1500;
+const TAG_TYPE_WWW = 1500;
+
+const LIB_FILENAME = {
+  win32: 'safe_app.dll',
+  darwin: 'libsafe_app.dylib',
+  linux: 'libsafe_app.so'
+}[os.platform()];
+
+const SYSTEM_URI_LIB_FILENAME = {
+  win32: './system_uri.dll',
+  darwin: './libsystem_uri.dylib',
+  linux: './libsystem_uri.so'
+}[os.platform()];
+
+
+module.exports = {
+  LIB_FILENAME,
+  SYSTEM_URI_LIB_FILENAME,
+
+  TAG_TYPE_DNS,
+  TAG_TYPE_WWW
+};

--- a/src/native/_system_uri.js
+++ b/src/native/_system_uri.js
@@ -1,12 +1,13 @@
 const path = require('path');
 const FFI = require('ffi');
-
-const dir = path.dirname(__filename);
+const SYSTEM_URI_LIB_FILENAME = require('../consts').SYSTEM_URI_LIB_FILENAME;
 
 const h = require('./helpers');
 const t = require('./types');
 
-const ffi = FFI.Library(path.join(dir, 'libsystem_uri'), {
+const dir = path.dirname(__filename);
+
+const ffi = FFI.Library(path.join(dir, SYSTEM_URI_LIB_FILENAME), {
   open: [t.i32, ['string'] ],
   install: [t.i32, ['string', //bundle
                     'string', //vendor

--- a/src/native/lib.js
+++ b/src/native/lib.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const FFI = require('ffi');
+const LIB_FILENAME = require('../consts').LIB_FILENAME;
 
 const dir = path.dirname(__filename);
 
@@ -17,7 +18,7 @@ api.forEach(function(mod){
   }
 });
 
-const ffi = FFI.Library(path.join(dir, 'libsafe_app'), ffiFunctions);
+const ffi = FFI.Library(path.join(dir, LIB_FILENAME), ffiFunctions);
 
 for (const key in mappings) {
   ffi[key].fn_name = key;


### PR DESCRIPTION
Using a newly added `src/consts.js`-file for record keeping.

Refs MAID-1947 .