### PR TITLE
fix/reject the promise if the API args formatter throws an error

### DIFF
--- a/src/api/mutable.js
+++ b/src/api/mutable.js
@@ -201,8 +201,8 @@ class Values extends h.NetworkObject {
 class MutableData extends h.NetworkObject {
   constructor(app, mdataRef) {
     super(app, mdataRef);
-    this.entriesRef = null;
-    this.permissionsRef = null;
+    this.entriesRef = 0;
+    this.permissionsRef = 0;
   }
 
   static free(app, ref) {
@@ -222,15 +222,15 @@ class MutableData extends h.NetworkObject {
   }
 
   getVersion() {
-    return lib.mdata_get_version(this.app, this.mdataRef);
+    return lib.mdata_get_version(this.app.connection, this.ref);
   }
 
   get(key) {
-    return lib.mdata_get_value(this.app, this.mdataRef, key.ptr, key.len);
+    return lib.mdata_get_value(this.app.connection, this.ref, key.ptr, key.len);
   }
 
   put() {
-    return lib.mdata_put(this.app, this.mdataRef, this.permissionsRef, this.entriesRef);
+    return lib.mdata_put(this.app.connection, this.ref, this.permissionsRef, this.entriesRef);
   }
 
   getEntries() {

--- a/src/native/_base.js
+++ b/src/native/_base.js
@@ -60,10 +60,6 @@ module.exports = {
         // the internal function that wraps the
         // actual function call
 
-        // if there is a formatter, we are reformatting
-        // the incoming arguments first
-        const args = formatter ? formatter.apply(formatter, arguments): Array.prototype.slice.call(arguments);
-
         // compile the callback-types-definiton
         let types = ['pointer', i32]; // we always have: user_context, error
         if (Array.isArray(rTypes)) {
@@ -72,6 +68,16 @@ module.exports = {
           types.push(rTypes);
         }
         return new Promise((resolve, reject) => {
+          // if there is a formatter, we are reformatting
+          // the incoming arguments first
+          let args;
+          try {
+            args = formatter ? formatter.apply(formatter, arguments): Array.prototype.slice.call(arguments);
+          } catch(err) {
+            // reject promise if error is thrown by the formatter
+            return reject(err);
+          }
+
           // append user-context and callback
           // to the arguments
           args.push(ref.NULL);

--- a/test/mutuable_data.js
+++ b/test/mutuable_data.js
@@ -7,32 +7,171 @@ const createAuthenticatedTestApp = h.createAuthenticatedTestApp;
 describe('Mutable Data', () => {
   const app = createAuthenticatedTestApp();
   const TAG_TYPE = 15639;
+  const TAG_TYPE_RESERVED = 10000;
+  const TAG_TYPE_INVALID = '_invalid_tag';
+  const TEST_NAME_PRIVATE = 'test-name-private-01010101010101';
+  const TEST_NAME_PUBLIC  = 'test-name-public--01010101010101';
+  const TEST_NAME_INVALID = 'name-shorter-than-32-bytes-long';
 
-  it('create random entry and read its name', () => app.mutableData.newRandomPublic(TAG_TYPE)
-          .then((m) => m.getNameAndTag())
-          .then((r) => {
-            should(r.name).not.be.undefined();
-            should(r.tag).equal(TAG_TYPE);
-          }));
+  describe('Create with invalid values', () => {
+    it.skip('create random public with reserved tag type', () => {
+      return should(app.mutableData.newRandomPublic(TAG_TYPE_RESERVED)).be.rejected();
+    });
 
-  it('create random private entry and read its name', () => app.mutableData.newRandomPrivate(TAG_TYPE)
-          .then((m) => m.getNameAndTag())
-          .then((r) => {
-            should(r.name).not.be.undefined();
-            should(r.tag).equal(TAG_TYPE);
-          }));
+    it.skip('create random private with reserved tag type', () => {
+      return should(app.mutableData.newRandomPrivate(TAG_TYPE_RESERVED)).be.rejected();
+    });
 
-  it('create custom private entry and read its name', () => app.mutableData.newPrivate('test-name-private-01010101010101', TAG_TYPE)
-          .then((m) => m.getNameAndTag())
-          .then((r) => {
-            should(r.name).not.be.undefined();
-            should(r.tag).equal(TAG_TYPE);
-          }));
+    it('create random public with invalid tag vaue', () => {
+      return should(app.mutableData.newRandomPublic(TAG_TYPE_INVALID)).be.rejected();
+    });
 
-  it('create custom public entry and read its name', () => app.mutableData.newPublic('test-name-public-010101010101010', TAG_TYPE)
-          .then((m) => m.getNameAndTag())
-          .then((r) => {
-            should(r.name).not.be.undefined();
-            should(r.tag).equal(TAG_TYPE);
-          }));
+    it('create random private with invalid tag value', () => {
+      return should(app.mutableData.newRandomPrivate(TAG_TYPE_INVALID)).be.rejected();
+    });
+
+    it.skip('create custom public with reserved tag type', () => {
+      return should(app.mutableData.newPublic(TEST_NAME_PUBLIC, TAG_TYPE_RESERVED)).be.rejected();
+    });
+
+    it.skip('create custom private with reserved tag type', () => {
+      return should(app.mutableData.newPrivate(TEST_NAME_PRIVATE, TAG_TYPE_RESERVED)).be.rejected();
+    });
+
+    it('create custom public with invalid tag value', () => {
+      return should(app.mutableData.newPublic(TEST_NAME_PUBLIC, TAG_TYPE_INVALID)).be.rejected();
+    });
+
+    it('create custom private with invalid tag value', () => {
+      return should(app.mutableData.newPrivate(TEST_NAME_PRIVATE, TAG_TYPE_INVALID)).be.rejected();
+    });
+
+    it('create custom public with invalid name', () => {
+      return should(app.mutableData.newPublic(TEST_NAME_INVALID, TAG_TYPE)).be.rejected();
+    });
+
+    it('create custom private with invalid name', () => {
+      return should(app.mutableData.newPrivate(TEST_NAME_INVALID, TAG_TYPE)).be.rejected();
+    });
+  })
+
+  describe('MutableData info', () => {
+    it('create random public entry and read its name', () =>
+        app.mutableData.newRandomPublic(TAG_TYPE)
+            .then((m) => m.getNameAndTag())
+            .then((r) => {
+              should(r.name).not.be.undefined();
+              should(r.tag).equal(TAG_TYPE);
+            })
+    );
+
+    it('create random private entry and read its name', () =>
+        app.mutableData.newRandomPrivate(TAG_TYPE)
+            .then((m) => m.getNameAndTag())
+            .then((r) => {
+              should(r.name).not.be.undefined();
+              should(r.tag).equal(TAG_TYPE);
+            })
+    );
+
+    it('create custom public entry and read its name', () =>
+        app.mutableData.newPublic(TEST_NAME_PUBLIC, TAG_TYPE)
+            .then((m) => m.getNameAndTag())
+            .then((r) => {
+              should(r.name).not.be.undefined();
+              // test XOR_NAME generation algorithm applied to the name provided???
+              should(r.name).have.length(TEST_NAME_PUBLIC.length);
+              should(r.tag).equal(TAG_TYPE);
+            })
+    );
+
+    it('create custom private entry and read its name', () =>
+        app.mutableData.newPrivate(TEST_NAME_PRIVATE, TAG_TYPE)
+            .then((m) => m.getNameAndTag())
+            .then((r) => {
+              should(r.name).not.be.undefined();
+              // test XOR_NAME generation algorithm applied to the name provided???
+              should(r.name).have.length(TEST_NAME_PUBLIC.length);
+              should(r.tag).equal(TAG_TYPE);
+            })
+    );
+
+    it.only('mdata version', () => {
+      return app.mutableData.newRandomPrivate(TAG_TYPE)
+          .then((m) => m.put().then(() => m.getVersion()))
+          .then((version) => {
+            should(version).equal(0);
+            // test that after a change in mdata (not in the entries) version is incremented
+          })
+
+    });
+  });
+
+  describe('Entries', () => {
+      it('get non-existing key', () => app.mutableData.newRandomPrivate(TAG_TYPE)
+          .then((md) => md.get('_non-existing-key'))
+          .then((value) => {
+            console.log("value:", value);
+            should(value).not.be.undefined();
+          })
+      );
+
+      it('insert and get a single entry', () => {
+      });
+
+      it('update a single entry', () => {
+      });
+
+      it('update a single entry and check version', () => {
+      });
+
+      it('delete a single entry', () => {
+      });
+
+      it('get list of entries', () => {
+      });
+
+      it('get list of keys', () => {
+      });
+
+      it('get list of values', () => {
+      });
+
+      it('mutate entries in bulk and check versions', () => {
+      });
+
+      it('single mutation followed by a bulk mutation', () => {
+      });
+
+      it.skip('encrypt entry key', () => {
+      });
+
+      it.skip('encrypt entry value', () => {
+      });
+  });
+
+  describe('Permissions', () => {
+    it('get list of permissions', () => {
+    });
+
+    it('get list of user\'s permissions', () => {
+    });
+
+    it('insert a permission', () => {
+    });
+
+    it('update a permission', () => {
+    });
+
+    it('delete a permission', () => {
+    });
+
+  });
+
+  describe('Owners', () => {
+    it('change oenwership', () => {
+    });
+  });
+
+
 });


### PR DESCRIPTION
Even that this scenario may be due to programming errors, I think we should reject the promise to make it consistent with the case of input validation error coming from the FFI layer in which case the API would be rejecting the promise.