### PR TITLE
Fixed native library copy script.

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,7 @@
     "build-system-uri": "cd system_uri && cargo build && cd ../ && cp -f system_uri/target/debug/*system_uri* ./src/native",
     "build-safe-lib": "cd native/safe_app && cargo build --features \"use-mock-routing testing\" && cd ../../ && cp -f native/target/debug/deps/*safe_app* ./src/native",
     "build-libs": "npm run build-system-uri && npm run build-safe-lib",
-    
-    "prepublish": "npm run build-libs",
+    "postinstall": "npm run build-libs",
     "pretest": "npm run build-libs",
     "docs": "documentation build --config etc/documentation.yml --github true --output docs --format html src/**",
     "serve-docs": "documentation serve --config etc/documentation.yml --github true --output docs --format html src/**",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build-libs-release": "npm run build-system-uri-release && npm run build-safe-app-release",
 
     "build-system-uri": "cd system_uri && cargo build && cd ../ && cp -f system_uri/target/debug/*system_uri* ./src/native",
-    "build-safe-lib": "cd native/safe_app && cargo build --features \"use-mock-routing testing\" && cd ../../ && cp -f native/target/debug/*safe_app* ./src/native",
+    "build-safe-lib": "cd native/safe_app && cargo build --features \"use-mock-routing testing\" && cd ../../ && cp -f native/target/debug/deps/*safe_app* ./src/native",
     "build-libs": "npm run build-system-uri && npm run build-safe-lib",
     
     "prepublish": "npm run build-libs",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build-libs-release": "npm run build-system-uri-release && npm run build-safe-app-release",
 
     "build-system-uri": "cd system_uri && cargo build && cd ../ && cp -f system_uri/target/debug/*system_uri* ./src/native",
-    "build-safe-lib": "cd native/safe_app && cargo build --features \"use-mock-routing testing\" && cd ../../ && cp -f native/target/debug/deps/*safe_app* ./src/native",
+    "build-safe-lib": "cd native/safe_app && cargo build --features \"use-mock-routing testing\" && cd ../../ && cp -rf native/target/debug/deps/*safe_app* ./src/native",
     "build-libs": "npm run build-system-uri && npm run build-safe-lib",
     "postinstall": "npm run build-libs",
     "pretest": "npm run build-libs",


### PR DESCRIPTION
When I tried to build this on linux the build script failed when it tried to copy the dynamic library from the wrong directory. This commit fixes things for me, though if you think it does the wrong thing let me know.

As a side node it seems like building safe_core without `--features "use-mock-routing testing"` does not compile right now. I assume that this is because there is stuff from routing/crust that is not ready yet.