### PR TITLE
prepublish -> postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build-safe-lib": "cd native/safe_app && cargo build --features \"use-mock-routing testing\" && cd ../../ && cp -f native/target/debug/*safe_app* ./src/native",
     "build-libs": "npm run build-system-uri && npm run build-safe-lib",
     
-    "prepublish": "npm run build-libs",
+    "postinstall": "npm run build-libs",
     "pretest": "npm run build-libs",
     "docs": "documentation build --config etc/documentation.yml --github true --output docs --format html src/**",
     "serve-docs": "documentation serve --config etc/documentation.yml --github true --output docs --format html src/**",


### PR DESCRIPTION
I changed the name of the top level compile-on-install hook. `prepublish` runs when you `npm install` the root package, but not when you install it as a dependency. In reading about the issue is seems like the node community had decided that `prepublish` should pretty much only be used for running transpilers that emit javascript artifacts which have to end up in the final tarball. I think `postinstall` should be triggered at all the right times.

This blog has some more info on why prepublish behaves the way that it does: https://blog.greenkeeper.io/what-is-npm-s-prepublish-and-why-is-it-so-confusing-a948373e6be1#.mk97sy8ru