### PR TITLE
chore/CI Cleaning up remainders from rust-compile times

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ out
 src/native/*.dll
 .cache/
 .npmignore
+native
+system_uri

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,6 @@ cache:
     - node_modules
 
 before_install:
-  - curl -s https://static.rust-lang.org/rustup.sh > rustup.sh && sh rustup.sh --prefix=~/rust --spec=1.14.0 -y --disable-sudo
   - "[[ ${TRAVIS_OS_NAME} = linux ]] && export CXX=g++-4.8 || echo 'skipped'"
 
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,3 +29,5 @@ install:
 test_script:
   - npm run lint
   - npm test
+
+build: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,10 +24,6 @@ install:
   - ps: Install-Product node $env:nodejs_version $env:platform
   - node --version
   - npm --version
-  - ps: |
-        $url = "https://github.com/maidsafe/QA/raw/master/Powershell%20Scripts/AppVeyor"
-        cmd /c curl -fsSL -o "Install Rustup.ps1" "$url/Install%20Rustup.ps1"
-        . ".\Install Rustup.ps1"
   - npm install
 
 test_script:


### PR DESCRIPTION
As cUrl breaks on latest appveyor, I took the opportunity to clean up
the remainders of having to compile rust within our CI and added some
things related to that to the .gitignore.

This should fix any CI failing because of that.