### PR TITLE
feat/Provide an option to download libraries for MockVault or real network

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ install:
   - node --version
   - npm --version
   # also downloads the build for release version
-  - npm install
+  - NODE_ENV=dev npm install
 
 script:
   - npm run lint

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ safe_app nodejs library.
 
 The external libraries will automatically be downloaded when you run `npm install`.
 
+If you are working on a development environment, you can run `NODE_ENV=dev npm install` instead in order to get the `safe_client` libraries which use the `MockVault` file rather than connecting to the SAFE Network.
+
 # License
 
 Licensed under either of

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,7 @@ install:
   - ps: Install-Product node $env:nodejs_version $env:platform
   - node --version
   - npm --version
-  - npm install
+  - NODE_ENV=dev npm install
 
 test_script:
   - npm run lint

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/maidsafe/safe_app_nodejs#readme",
   "dependencies": {
-    "deps_downloader": "git+https://github.com/gnunicorn/deps_downloader.git",
+    "deps_downloader": "git+https://github.com/maidsafe/deps_downloader.git",
     "enum": "^2.3.0",
     "ffi": "^2.2.0",
     "ref": "^1.3.3",
@@ -55,10 +55,15 @@
       "mirror": "https://github.com/krishnaIndia/safe_core/releases/download/v",
       "version": "0.1.0-pre34",
       "targetDir": "src/native",
-      "filename": "safe_app-dev",
+      "filename": "safe_app",
       "filePattern": "^.*\\.(dll|so|dylib)$"
     },
     "ENV": {
+      "dev": {
+        "safe_app": {
+          "filename": "safe_app-dev"
+        }
+      },
       "win32": {
         "libwinpthread-1": {
           "mirror": "https://github.com/gnunicorn/safe_core/releases/download/v",

--- a/package.json
+++ b/package.json
@@ -56,12 +56,18 @@
       "version": "0.1.0-pre37",
       "targetDir": "src/native",
       "filename": "safe_app",
-      "filePattern": "^.*\\.(dll|so|dylib)$"
+      "filePattern": "^.*\\.(dll|so|dylib)$",
+      "force": true
     },
     "ENV": {
       "dev": {
         "safe_app": {
           "filename": "safe_app-dev"
+        }
+      },
+      "nightly": {
+        "safe_app": {
+          "filename": "safe_app-nightly"
         }
       },
       "win32": {


### PR DESCRIPTION
This provides three options for downloading the `safe_app` lib (in all cases the version is fixed and hard-coded in the `package.json` just like it's been so far):
1- `npm install` will download the safe_app lib which connects with the real network
2- `NODE_ENV=dev` npm install will download the safe_app lib which connects with the mocked vault (the published lib's filename shall have `-dev` postfix)
3- `NODE_ENV=nightly` npm install will download the nightly build of the safe_app lib (the published lib's filename shall have `-nightly` postfix)