### PR TITLE
Maid 2238 - persist log file path 

### DIFF
--- a/etc/documentation.yml
+++ b/etc/documentation.yml
@@ -5,6 +5,7 @@ toc:
   - initializeApp
   - fromAuthURI
   - AppInfo
+  - InitOptions
 
   - name: App Interface
     description: the App and the API it exposes

--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -57,10 +57,14 @@ class AuthInterface {
   *
   * @param {SAFEApp} app - the SAFEApp instance that is wired to which
   * is also used to fetch the app's information from.
+  * @param {InitOptions} initialisation options
   */
   constructor(app) {
     this.app = app;
     this._registered = false;
+    if (app._options.hasOwnProperty('registerScheme') && !app._options.registerScheme) {
+      return;
+    }
     this.setupUri();
   }
 

--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -62,7 +62,7 @@ class AuthInterface {
   constructor(app) {
     this.app = app;
     this._registered = false;
-    if (app._options.hasOwnProperty('registerScheme') && !app._options.registerScheme) {
+    if (app.options.registerScheme === false) {
       return;
     }
     this.setupUri();

--- a/src/app.js
+++ b/src/app.js
@@ -22,14 +22,15 @@ class SAFEApp extends EventEmitter {
   * to receive network state updates
   * @param {InitOptions} initilalisation options
   */
-  constructor(appInfo, networkStateCallBack, options = {
-    log: true,
-    registerScheme: true
-  }) {
+  constructor(appInfo, networkStateCallBack, options) {
     super();
-    lib.init(options);
+    this.options = Object.assign({
+      log: true,
+      registerScheme: true
+    }, options);
+    console.log(this.options);
+    lib.init(this.options);
     this._appInfo = appInfo;
-    this.options = options;
     this.networkState = consts.NET_STATE_INIT;
     this._networkStateCallBack = networkStateCallBack;
     this.connection = null;
@@ -38,7 +39,7 @@ class SAFEApp extends EventEmitter {
       this[`_${key}`] = new api[key](this);
     });
 
-    if (options.log) {
+    if (this.options.log) {
       let filename = `${appInfo.name}.${appInfo.vendor}`.replace(/[^\w\d_\-.]/g, '_');
       filename = `${filename}.log`;
       lib.app_init_logging(filename)

--- a/src/app.js
+++ b/src/app.js
@@ -30,14 +30,18 @@ class SAFEApp extends EventEmitter {
     this.networkState = consts.NET_STATE_INIT;
     this._networkStateCallBack = networkStateCallBack;
     this.connection = null;
+    this.logFilePath = null;
     Object.getOwnPropertyNames(api).forEach((key) => {
       this[`_${key}`] = new api[key](this);
     });
 
-    if (!SAFEApp.logFilename && options.log) {
-      const filename = `${appInfo.name}.${appInfo.vendor}`.replace(/[^\w\d_\-.]/g, '_');
-      SAFEApp.logFilename = `${filename}.log`;
-      lib.app_init_logging(SAFEApp.logFilename);
+    if (options.log) {
+      let filename = `${appInfo.name}.${appInfo.vendor}`.replace(/[^\w\d_\-.]/g, '_');
+      filename = `${filename}.log`;
+      lib.app_init_logging(filename)
+        .then(() => lib.app_output_log_path(filename))
+        .then((logPath) => this.logFilePath = logPath)
+        .catch(err => console.error('Logger initilalisation failed', err));
     }
   }
 
@@ -221,7 +225,7 @@ class SAFEApp extends EventEmitter {
   logPath(logFilename) {
     let filename = logFilename;
     if (!logFilename) {
-      return SAFEApp.logFilename;
+      return this.logPath;
     }
     return lib.app_output_log_path(filename);
   }
@@ -292,7 +296,5 @@ class SAFEApp extends EventEmitter {
   }
 
 }
-
-SAFEApp.logFilename = null;
 
 module.exports = SAFEApp;

--- a/src/app.js
+++ b/src/app.js
@@ -22,11 +22,14 @@ class SAFEApp extends EventEmitter {
   * to receive network state updates
   * @param {InitOptions} initilalisation options
   */
-  constructor(appInfo, networkStateCallBack, options = {log: true, registerScheme: true}) {
+  constructor(appInfo, networkStateCallBack, options = {
+    log: true,
+    registerScheme: true
+  }) {
     super();
     lib.init(options);
     this._appInfo = appInfo;
-    this._options = options;
+    this.options = options;
     this.networkState = consts.NET_STATE_INIT;
     this._networkStateCallBack = networkStateCallBack;
     this.connection = null;
@@ -40,8 +43,8 @@ class SAFEApp extends EventEmitter {
       filename = `${filename}.log`;
       lib.app_init_logging(filename)
         .then(() => lib.app_output_log_path(filename))
-        .then((logPath) => this.logFilePath = logPath)
-        .catch(err => console.error('Logger initilalisation failed', err));
+        .then((logPath) => { this.logFilePath = logPath; })
+        .catch((err) => { console.error('Logger initilalisation failed', err); });
     }
   }
 
@@ -223,7 +226,7 @@ class SAFEApp extends EventEmitter {
   */
   /* eslint-disable class-methods-use-this */
   logPath(logFilename) {
-    let filename = logFilename;
+    const filename = logFilename;
     if (!logFilename) {
       return this.logPath;
     }

--- a/src/app.js
+++ b/src/app.js
@@ -28,7 +28,6 @@ class SAFEApp extends EventEmitter {
       log: true,
       registerScheme: true
     }, options);
-    console.log(this.options);
     lib.init(this.options);
     this._appInfo = appInfo;
     this.networkState = consts.NET_STATE_INIT;

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,5 @@
 const App = require('./app');
 const autoref = require('./helpers').autoref;
-const errConst = require('./error_const');
 const version = require('../package.json').version;
 
 /**
@@ -21,7 +20,7 @@ const version = require('../package.json').version;
 * holds the additional intialisation options for the App.
 * @param {Boolean=} registerScheme to register auth scheme with the OS. Defaults to true
 * @param {Boolean=} log to enable or disable back end logging. Defaults to true
-* @param {String=} libPath path to the folder where the native libs can 
+* @param {String=} libPath path to the folder where the native libs can
 *        be found. Defaults to current folder path.
 */
 
@@ -31,7 +30,7 @@ const version = require('../package.json').version;
  * @param {Function} [networkStateCallBack=null] callback function
  *        to receive network state updates
  * @param {InitOptions=} options initialisation options
- * 
+ *
  * @returns {Promise<SAFEApp>} promise to a SAFEApp instance
  * @example // Usage Example
  * const safe = require('safe');
@@ -54,8 +53,8 @@ const version = require('../package.json').version;
 function initializeApp(appInfo, networkStateCallBack, options) {
   try {
     const app = autoref(new App(appInfo, networkStateCallBack, options));
-    return Promise.resolve(app);   
-  } catch(e) {
+    return Promise.resolve(app);
+  } catch (e) {
     return Promise.reject(e);
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,5 @@
-
 const App = require('./app');
 const autoref = require('./helpers').autoref;
-const makeFfiError = require('./native/_error.js');
 const errConst = require('./error_const');
 const version = require('../package.json').version;
 
@@ -19,10 +17,21 @@ const version = require('../package.json').version;
 */
 
 /**
+* @typedef {Object} InitOptions
+* holds the additional intialisation options for the App.
+* @param {Boolean=} registerScheme to register auth scheme with the OS. Defaults to true
+* @param {Boolean=} log to enable or disable back end logging. Defaults to true
+* @param {String=} libPath path to the folder where the native libs can 
+*        be found. Defaults to current folder path.
+*/
+
+/**
  * The main entry point to create a new SAFEApp
  * @param {AppInfo} appInfo
- * @param {Function} [networkStateCallBack=null] optional callback function
- * to receive network state updates
+ * @param {Function} [networkStateCallBack=null] callback function
+ *        to receive network state updates
+ * @param {InitOptions=} options initialisation options
+ * 
  * @returns {Promise<SAFEApp>} promise to a SAFEApp instance
  * @example // Usage Example
  * const safe = require('safe');
@@ -42,17 +51,14 @@ const version = require('../package.json').version;
  *        // or wait for a result url
  *        ))
  */
-function initializeApp(appInfo, networkStateCallBack) {
-  const libLoadErr = App.failedToLoadLibs();
-  if (libLoadErr) {
-    return Promise.reject(
-      makeFfiError(errConst.FAILED_TO_LOAD_LIB.code,
-        errConst.FAILED_TO_LOAD_LIB.msg(libLoadErr)));
+function initializeApp(appInfo, networkStateCallBack, options) {
+  try {
+    const app = autoref(new App(appInfo, networkStateCallBack, options));
+    return Promise.resolve(app);   
+  } catch(e) {
+    return Promise.reject(e);
   }
-  const app = autoref(new App(appInfo, networkStateCallBack));
-  return Promise.resolve(app);
 }
-
 
 /**
  * If you have received a response URI (which you are allowed
@@ -63,10 +69,11 @@ function initializeApp(appInfo, networkStateCallBack) {
  * @param {String} authUri - the URI coming back from the Authenticator
  * @param {Function} [networkStateCallBack=null] optional callback function
  * to receive network state updates
+ * @param {InitOptions=} options initialisation options
  * @returns {Promise<SAFEApp>} promise to a SAFEApp instance
  */
-function fromAuthURI(appInfo, authUri, networkStateCallBack) {
-  return App.fromAuthUri(appInfo, authUri, networkStateCallBack);
+function fromAuthURI(appInfo, authUri, networkStateCallBack, options) {
+  return App.fromAuthUri(appInfo, authUri, networkStateCallBack, options);
 }
 
 module.exports = {

--- a/src/native/_system_uri.js
+++ b/src/native/_system_uri.js
@@ -9,8 +9,8 @@ const dir = path.dirname(__filename);
 let ffi = null;
 let isSysUriLibLoadErr = null;
 
-try {
-  ffi = FFI.Library(path.join(dir, SYSTEM_URI_LIB_FILENAME), {
+const init = (options) => {
+  ffi = FFI.Library(path.join(options.libPath || dir, SYSTEM_URI_LIB_FILENAME), {
     open: [t.i32, ['string'] ],
     install: [t.i32, ['string', //bundle
       'string', //vendor
@@ -20,10 +20,7 @@ try {
       'string', //schemes
     ] ],
   });
-} catch (err) {
-  console.error(`Failed to load system_uri binary => ${err}`);
-  isSysUriLibLoadErr = err;
-}
+};
 
 function openUri(uri) {
   if (!ffi) {
@@ -56,8 +53,8 @@ function registerUriScheme(appInfo, schemes) {
 // FIXME: As long as `safe-app` doesn't expose system uri itself, we'll
 // patch it directly on it. This should later move into its own sub-module
 // and take care of mobile support for other platforms, too.
-module.exports = function(other) {
+module.exports = function(other, options) {
   other.openUri = openUri;
   other.registerUriScheme = registerUriScheme;
-  other.isSysUriLibLoadErr = isSysUriLibLoadErr;
+  init(options);
 }

--- a/src/native/lib.js
+++ b/src/native/lib.js
@@ -6,7 +6,8 @@ const os = require('os');
 const dir = path.dirname(__filename);
 
 const api = require('./api');
-
+const makeFfiError = require('./_error.js');
+const errConst = require('./../error_const');
 const ffi = {};
 
 const RTLD_NOW = FFI.DynamicLibrary.FLAGS.RTLD_NOW;
@@ -14,56 +15,44 @@ const RTLD_GLOBAL = FFI.DynamicLibrary.FLAGS.RTLD_GLOBAL;
 const mode = RTLD_NOW | RTLD_GLOBAL;
 let lib = null;
 
-try {
-  if (os.platform() === 'win32') {
-    FFI.DynamicLibrary(path.resolve(__dirname, 'libwinpthread-1'), mode);
-  }
-  lib = FFI.DynamicLibrary(path.join(dir, LIB_FILENAME), mode);
-  ffi['isLibLoadErr'] = null;
-} catch (err) {
-  console.error(`Error while loading binary => ${err}`);
-  ffi['isLibLoadErr'] = err;
-}
-
-function retrieveFFI(key) {
-  if (!lib) {
-    return;
-  }
+ffi.init = (options) => {
   try {
-    return lib.get(key);
+    if (os.platform() === 'win32') {
+      FFI.DynamicLibrary(path.resolve(options.libPath || __dirname, 'libwinpthread-1'), mode);
+    }
+    lib = FFI.DynamicLibrary(path.join(options.libPath || dir, LIB_FILENAME), mode);
+    
+    api.forEach(function(mod){
+      if (!lib) {
+        throw new Error('Native library not initialised');
+      }
+      if (mod.functions){
+        for (const key in mod.functions) {
+          const funcDefinition = mod.functions[key];
+
+          ffi[key] = FFI.ForeignFunction(lib.get(key),
+                                         funcDefinition[0],
+                                         funcDefinition[1])
+        }
+      }
+      if (mod.api) {
+        for (const key in mod.api) {
+          ffi[key].fn_name = key;
+          let fn = mod.api[key](ffi, ffi[key]);
+          fn.fn_name = "[mapped]" + key;
+          ffi[key] = fn;
+        }
+      //   Object.assign(mappings, mod.api);
+      }
+    });
+    // FIXME: As long as `safe-app` doesn't expose system uri itself, we'll
+    // patch it directly on it. This should later move into its own sub-module
+    // and take care of mobile support for other platforms, too.
+    require('./_system_uri')(ffi, options);  
   } catch(e) {
-    console.log(`The following error occured for looking up function: ${key}. ->`, e);
+    throw makeFfiError(errConst.FAILED_TO_LOAD_LIB.code,
+        errConst.FAILED_TO_LOAD_LIB.msg(libLoadErr));
   }
-}
-
-api.forEach(function(mod){
-  if (!lib) {
-    return;
-  }
-  if (mod.functions){
-    for (const key in mod.functions) {
-      const funcDefinition = mod.functions[key];
-
-      ffi[key] = FFI.ForeignFunction(retrieveFFI(key),
-                                     funcDefinition[0],
-                                     funcDefinition[1])
-    }
-  }
-  if (mod.api) {
-    for (const key in mod.api) {
-      ffi[key].fn_name = key;
-      let fn = mod.api[key](ffi, ffi[key]);
-      fn.fn_name = "[mapped]" + key;
-      ffi[key] = fn;
-    }
-  //   Object.assign(mappings, mod.api);
-  }
-});
-
-
-// FIXME: As long as `safe-app` doesn't expose system uri itself, we'll
-// patch it directly on it. This should later move into its own sub-module
-// and take care of mobile support for other platforms, too.
-require('./_system_uri')(ffi);
+};
 
 module.exports = ffi;

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -8,7 +8,7 @@ function createTestApp(scope) {
     name: 'JS Test',
     vendor: 'MaidSafe Ltd.',
     scope
-  }));
+  }, null, {log: false}));
 }
 
 function createAnonTestApp(scope) {

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -8,7 +8,7 @@ function createTestApp(scope) {
     name: 'JS Test',
     vendor: 'MaidSafe Ltd.',
     scope
-  }, null, {log: false}));
+  }, null, { log: false }));
 }
 
 function createAnonTestApp(scope) {

--- a/test/index.js
+++ b/test/index.js
@@ -18,7 +18,7 @@ describe('External API', () => {
         vendor: 'MaidSafe Ltd.'
       };
 
-      return fromAuthURI(appInfo, uri, {log: false})
+      return fromAuthURI(appInfo, uri, { log: false })
         .then((app) => should(app.auth.registered).be.true());
     });
 
@@ -30,7 +30,7 @@ describe('External API', () => {
         vendor: 'MaidSafe Ltd.'
       };
 
-      return fromAuthURI(appInfo, uri, {log: false})
+      return fromAuthURI(appInfo, uri, { log: false })
         .then((app) => should(app.auth.registered).not.be.true());
     });
   });

--- a/test/index.js
+++ b/test/index.js
@@ -18,7 +18,7 @@ describe('External API', () => {
         vendor: 'MaidSafe Ltd.'
       };
 
-      return fromAuthURI(appInfo, uri)
+      return fromAuthURI(appInfo, uri, {log: false})
         .then((app) => should(app.auth.registered).be.true());
     });
 
@@ -30,7 +30,7 @@ describe('External API', () => {
         vendor: 'MaidSafe Ltd.'
       };
 
-      return fromAuthURI(appInfo, uri)
+      return fromAuthURI(appInfo, uri, {log: false})
         .then((app) => should(app.auth.registered).not.be.true());
     });
   });


### PR DESCRIPTION
Persist the log file path after initialisation.

Add options to enable/disable rust logs, to register scheme with OS and also to pass path for loading the native libraries.