### PR TITLE
Fix reference to undefined `libLoadError`

### DIFF
--- a/src/native/lib.js
+++ b/src/native/lib.js
@@ -51,7 +51,7 @@ ffi.init = (options) => {
     require('./_system_uri')(ffi, options);  
   } catch(e) {
     throw makeFfiError(errConst.FAILED_TO_LOAD_LIB.code,
-        errConst.FAILED_TO_LOAD_LIB.msg(libLoadErr));
+        errConst.FAILED_TO_LOAD_LIB.msg(e.toString()));
   }
 };
 


### PR DESCRIPTION
### Motivation

When starting my Safe Browser on Linux, I get the following error:

```
Uncaught Exception:
ReferenceError: libLoadErr is not defined
    at Object.ffi.init (/home/maidsafe/safe_browser/app/node_modules/safe-app/src/native/lib.js:54:41)
```

It looks like this code was recently [added in #121](https://github.com/maidsafe/safe_app_nodejs/pull/121/files#diff-6761522e330cc8a833ac57828966389eR54).

### Changes

Print the error itself, rather than an undefined variable.

### Notes

This is my first MaidSafe contribution; I intend to make more, so please let me know if there's any particular protocol I should be following for PRs (such as opening Jira ticket first?) Thank you!