### PR TITLE
Setup Packaging MAID-2332

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-#safe-node-app
-
-A nodejs API for the [SAFE Network](http://maidsafe.net).
+# safe-node-app
 
 A safe_app library for [Node.js](https://nodejs.org/).
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# safe-node-app
+# safe_app_nodejs
 
 A safe_app library for [Node.js](https://nodejs.org/).
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# safe_app_nodejs
+#safe-node-app
+
+A nodejs API for the [SAFE Network](http://maidsafe.net).
 
 **Maintainer:** Krishna Kumar (krishna.kumar@maidsafe.net)
 
@@ -14,17 +16,21 @@ safe_app Node.js library.
 
 ## Documentation
 
-The documentation for the safe_app Node.js API is available at http://docs.maidsafe.net/safe_app_nodejs/.
+The documentation for the safe-node-app Node.js API is available at http://docs.maidsafe.net/safe_app_nodejs/.
+
+## Installation
+
+`yarn add @maidsafe/safe-node-app`
 
 ## External Libraries
 
-The external libraries will automatically be downloaded when you run `npm install`.
+The external libraries will automatically be downloaded when you run `yarn install`.
 
-If you are working on a development environment, you can run `NODE_ENV=dev npm install` instead in order to get the `safe_client` libraries which use the `MockVault` file rather than connecting to the SAFE Network.
+If you are working on a development environment, you can run `NODE_ENV=dev yarn install` instead in order to get the `safe_client` libraries which use the `MockVault` file rather than connecting to the SAFE Network.
 
 ## Testing
 
-To run the tests locally, make sure you installed the `safe_client` libraries with `NODE_ENV=dev npm install`, then you can run them by executing `npm test`.
+To run the tests locally, make sure you installed the `safe_client` libraries with `NODE_ENV=dev yarn install`, then you can run them by executing `yarn test`.
 
 You may possibly be compiling your own [safe_app](https://github.com/maidsafe/safe_client_libs/tree/master/safe_app) library for testing purposes. In this case, if you want to be able to run the tests, make sure to include `testing` in your build features when compiling `safe_app` in `safe_client_libs`, i.e. `cargo build --release --features "use-mock-routing testing"`.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maidsafe/safe-node-app",
-  "version": "0.2.1-5",
+  "version": "0.2.1-6",
   "description": "",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "safe-app",
-  "version": "0.2.0",
+  "name": "@maidsafe/safe-node-app",
+  "version": "0.2.1-5",
   "description": "",
   "main": "src/index.js",
   "scripts": {
@@ -12,14 +12,19 @@
     "test": "mocha",
     "test-coverage": "istanbul cover _mocha --report lcovonly -- -R spec",
     "publish-coverage": "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
-    "pre-pack": "npm run lint"
+    "pre-pack": "yarn run lint",
+    "prepush": "yarn run test && yarn run lint",
+    "prepublish": "yarn run test && yarn run lint"
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/maidsafe/safe_app_nodejs.git"
   },
-  "author": "",
-  "license": "ISC",
+  "author": {
+    "name": "MaidSafe",
+    "email": "qa@maidsafe.net",
+    "url": "https://github.com/maidsafe"
+  },
   "bugs": {
     "url": "https://github.com/maidsafe/safe_app_nodejs/issues"
   },
@@ -39,6 +44,7 @@
     "eslint": "^3.12.2",
     "eslint-config-airbnb-base": "^11.0.0",
     "eslint-plugin-import": "^2.2.0",
+    "husky": "^0.14.3",
     "istanbul": "^0.4.5",
     "jsdoc": "^3.4.3",
     "mocha": "^3.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1167,6 +1167,10 @@ chokidar@^1.2.0:
   optionalDependencies:
     fsevents "^1.0.0"
 
+ci-info@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.1.1.tgz#47b44df118c48d2597b56d342e7e25791060171a"
+
 circular-json@^0.3.1:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.3.tgz#815c99ea84f6809529d2f45791bdf82711352d66"
@@ -2352,6 +2356,14 @@ http-signature@~1.1.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
+husky@^0.14.3:
+  version "0.14.3"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-0.14.3.tgz#c69ed74e2d2779769a17ba8399b54ce0b63c12c3"
+  dependencies:
+    is-ci "^1.0.10"
+    normalize-path "^1.0.0"
+    strip-indent "^2.0.0"
+
 ignore@^3.2.0:
   version "3.3.4"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.4.tgz#85ab6d0a9ca8b27b31604c09efe1c14dc21ab872"
@@ -2460,6 +2472,12 @@ is-builtin-module@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-builtin-module/-/is-builtin-module-1.0.0.tgz#540572d34f7ac3119f8f76c30cbc1b1e037affbe"
   dependencies:
     builtin-modules "^1.0.0"
+
+is-ci@^1.0.10:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-1.0.10.tgz#f739336b2632365061a9d48270cd56ae3369318e"
+  dependencies:
+    ci-info "^1.0.0"
 
 is-data-descriptor@^0.1.4:
   version "0.1.4"
@@ -3276,6 +3294,10 @@ normalize-package-data@^2.3.2, normalize-package-data@^2.3.4:
     is-builtin-module "^1.0.0"
     semver "2 || 3 || 4 || 5"
     validate-npm-package-license "^3.0.1"
+
+normalize-path@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-1.0.0.tgz#32d0e472f91ff345701c15a8311018d3b0a90379"
 
 normalize-path@^2.0.0, normalize-path@^2.0.1:
   version "2.1.1"
@@ -4397,6 +4419,10 @@ strip-indent@^1.0.1:
   resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-1.0.1.tgz#0c7962a6adefa7bbd4ac366460a638552ae1a0a2"
   dependencies:
     get-stdin "^4.0.1"
+
+strip-indent@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
 
 strip-json-comments@^2.0.0, strip-json-comments@~2.0.1:
   version "2.0.1"


### PR DESCRIPTION
As part of build improvements.

An updated build can be released via `yarn publish --access public [ --tag <tagname, eg beta> ]`

Current NPM version is marked as beta, once we're satisfied the repos are running on this, I'd suggest we bump, the NPM version to full version and updated the other app PRs to work with this.