### PR TITLE
fix/Rely on the safe-core network observer callbacks for state change upon reconnection

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -331,17 +331,7 @@ class SAFEApp extends EventEmitter {
   * Must be invoked when the client decides to connect back after the connection is disconnected.
   */
   reconnect() {
-    return new Promise((res, rej) => {
-      lib.app_reconnect(this.connection)
-        .then(() => {
-          this._networkStateUpdated(null, { error_code: 0 }, consts.NET_STATE_CONNECTED);
-          res();
-        })
-        .catch((e) => {
-          this._networkStateUpdated(null, { error_code: 0 }, consts.NET_STATE_DISCONNECTED);
-          rej(e);
-        });
-    });
+    return lib.app_reconnect(this.connection);
   }
 
 


### PR DESCRIPTION
In previous version of safe_client_libs, the network observer wasn't sending the state change callback upon a re-connection, but it now does it, therefore we don't need to force the notifications on the safe_app_nodejs side as they get triggered twice now.