### PR TITLE
version change to 0.4.1

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,5 +1,12 @@
 # safe_app nodejs Change Log
 
+## 0.4.1
+
+- Expose Constants which can be used by Apps
+- Rely on the safe-core network observer callbacks upon a reconnection
+- Minor code refactor
+- Uses e9080ac commit version from [alpha-2 branch](https://github.com/maidsafe/safe_client_libs/tree/f40fef47973294b03f8e37dade8edaa8e2da20c9)
+
 ## 0.4.0
 
 - Compatible with safe_app v0.4.0

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -4,7 +4,6 @@
 
 - Expose Constants which can be used by Apps
 - Rely on the safe-core network observer callbacks upon a reconnection
-- Minor code refactor
 - Uses e9080ac commit version from [alpha-2 branch](https://github.com/maidsafe/safe_client_libs/tree/f40fef47973294b03f8e37dade8edaa8e2da20c9)
 
 ## 0.4.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maidsafe/safe-node-app",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "",
   "main": "src/index.js",
   "scripts": {
@@ -60,7 +60,7 @@
     },
     "safe_app": {
       "mirror": "https://s3.eu-west-2.amazonaws.com/safe-client-libs",
-      "version": "v0.4.0",
+      "version": "e9080ac",
       "targetDir": "src/native",
       "filename": "safe_app",
       "filePattern": "^.*\\.(dll|so|dylib)$",


### PR DESCRIPTION
- Expose Constants which can be used by Apps
- Rely on the safe-core network observer callbacks upon a reconnection
- Minor code refactor
- Uses e9080ac commit version from safe_client_libs, alpha-2 branch