### PR TITLE
MAID-2130 feat/partial-content: Add option for partial content 

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -6,6 +6,7 @@
 - Upgrade istanbul library to support async/await and remove errors when getting testing coverage
 
 ### Added
+- Support for webFetch-ing partial content by providing the range of bytes to retrieve
 - New tests were added as well as some enhancements to increase test coverage
 
 ### SAFE libraries Dependencies

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "test-coverage": "istanbul cover _mocha --report lcovonly -- -R spec --recursive test",
     "publish-coverage": "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
     "pre-pack": "yarn run lint",
-    "prepush": "yarn run test && yarn run lint",
-    "prepublish": "yarn run test && yarn run lint"
+    "prepush": "yarn run lint && yarn run test",
+    "prepublish": "yarn run lint && yarn run test"
   },
   "repository": {
     "type": "git",

--- a/src/app.js
+++ b/src/app.js
@@ -132,8 +132,8 @@ class SAFEApp extends EventEmitter {
   * @param {Object} range range of bytes to be retrieved.
   * The `start` attribute is expected to be the start offset, while the
   * `end` attribute of the `range` object the end position (both inclusive)
-  * to be retrieved, e.g. with `range: { start: 2, end: 3 }` the 2nd
-  * and 3rd bytes of data will be retrieved.
+  * to be retrieved, e.g. with `range: { start: 2, end: 3 }` the 3rd
+  * and 4th bytes of data will be retrieved.
   * If `end` is not specified, the bytes retrived will be from the `start` offset
   * untill the end of the file.
   * The ranges values are also used to populate the `Content-Range` and

--- a/src/app.js
+++ b/src/app.js
@@ -131,8 +131,8 @@ class SAFEApp extends EventEmitter {
   * holds additional options for the `webFetch` function.
   * @param {Object} range range of bytes to be retrieved.
   * The `start` attribute is expected to be the start offset, while the
-  * `end` attribute of the `range` object the end position (non inclusive)
-  * to be retrieved, e.g. with `range: { start: 1, end: 3 }` only the 2nd
+  * `end` attribute of the `range` object the end position (both inclusive)
+  * to be retrieved, e.g. with `range: { start: 2, end: 3 }` the 2nd
   * and 3rd bytes of data will be retrieved.
   * If `end` is not specified, the bytes retrived will be from the `start` offset
   * untill the end of the file.
@@ -242,7 +242,6 @@ class SAFEApp extends EventEmitter {
         let start = consts.pubConsts.NFS_FILE_START;
         let end;
         let fileSize;
-        let fileFinalByteIndex;
         let lengthToRead = consts.pubConsts.NFS_FILE_END;
         let endByte;
 
@@ -251,13 +250,9 @@ class SAFEApp extends EventEmitter {
           range = options.range;
           start = range.start;
           fileSize = await openedFile.size();
-          end = range.end || fileSize;
-          fileFinalByteIndex = fileSize - 1;
-          lengthToRead = end - start;
+          end = range.end || fileSize - 1;
 
-          if (end === fileFinalByteIndex) {
-            lengthToRead += 1;
-          }
+          lengthToRead = (end - start) + 1; // account for 0 index
         }
         const data = await openedFile.read(start, lengthToRead);
         const mimeType = mime.getType(nodePath.extname(filePath)) || 'application/octet-stream';
@@ -271,7 +266,7 @@ class SAFEApp extends EventEmitter {
 
         if (range) {
           endByte = (end === fileSize) ? fileSize - 1 : end;
-          response.headers['Content-Range'] = `bytes ${start}-${endByte}/${fileFinalByteIndex}`;
+          response.headers['Content-Range'] = `bytes ${start}-${endByte}/${fileSize}`;
           response.headers['Content-Length'] = lengthToRead;
         }
 

--- a/test/browsing.js
+++ b/test/browsing.js
@@ -232,41 +232,40 @@ describe('Browsing', () => {
   describe('WebFetch partial content', () => {
     it('fetch partial content', () => {
       const content = `hello world, on ${Math.round(Math.random() * 100000)}`;
-      const numberOfBytes = content.length - 1;
-      const bytesToRetrieve = 6;
       const startByte = 3;
+      const endByte = 9;
+      const exptedReturn = 'lo worl';
 
       return createRandomDomain(content, '/streaming.mp4')
         .then((domain) => createAnonTestApp()
           .then((app) => app.webFetch(`safe://${domain}/streaming.mp4`,
-                    { range: { start: startByte, end: startByte + bytesToRetrieve } })
+                    { range: { start: startByte, end: endByte } })
             .then((data) => {
-              should(data.body.toString()).equal('lo wor');
+              should(data.body.toString()).equal(exptedReturn);
               should(data.body.toString()).equal(
-                          content.substring(startByte, startByte + bytesToRetrieve));
-              should(data.headers['Content-Range']).equal(`bytes ${startByte}-${startByte + (bytesToRetrieve)}/${numberOfBytes}`);
-              should(data.headers['Content-Length']).equal(bytesToRetrieve);
+                          content.substring(startByte, endByte + 1));
+              should(data.headers['Content-Range']).equal(`bytes ${startByte}-${endByte}/${content.length}`);
+              should(data.headers['Content-Length']).equal(exptedReturn.length);
             })
         ));
     }).timeout(20000);
 
     it('fetches partial content starting at 0', () => {
       const content = `hello world, on ${Math.round(Math.random() * 100000)}`;
-      const numberOfBytes = content.length - 1;
-
-      const bytesToRetrieve = 7;
+      const exptedReturn = 'hello wo';
+      const endByte = 7;
       const startByte = 0;
 
       return createRandomDomain(content, '/streaming.mp4')
         .then((domain) => createAnonTestApp()
           .then((app) => app.webFetch(`safe://${domain}/streaming.mp4`,
-                    { range: { start: startByte, end: startByte + bytesToRetrieve } })
+                    { range: { start: startByte, end: endByte } })
             .then((data) => {
-              should(data.body.toString()).equal('hello w');
+              should(data.body.toString()).equal(exptedReturn);
               should(data.body.toString()).equal(
-                          content.substring(startByte, startByte + bytesToRetrieve));
-              should(data.headers['Content-Range']).equal(`bytes ${startByte}-${startByte + (bytesToRetrieve)}/${numberOfBytes}`);
-              should(data.headers['Content-Length']).equal(bytesToRetrieve);
+                          content.substring(startByte, endByte + 1));
+              should(data.headers['Content-Range']).equal(`bytes ${startByte}-${endByte}/${content.length}`);
+              should(data.headers['Content-Length']).equal(exptedReturn.length);
             })
         ));
     }).timeout(20000);
@@ -279,7 +278,7 @@ describe('Browsing', () => {
           .then((app) => app.webFetch(`safe://${domain}/streaming.mp4`, { range: { start: 0, end: numberOfBytes } })
             .then((data) => {
               should(data.body.toString()).equal(content);
-              should(data.headers['Content-Range']).equal(`bytes 0-${numberOfBytes}/${numberOfBytes}`);
+              should(data.headers['Content-Range']).equal(`bytes 0-${numberOfBytes}/${content.length}`);
               should(data.headers['Content-Length']).equal(content.length);
             })
         ));
@@ -295,7 +294,7 @@ describe('Browsing', () => {
           .then((app) => app.webFetch(`safe://${domain}/streaming.mp4`, { range: { start: startByte } })
             .then((data) => {
               should(data.body.toString()).equal(content.substring(startByte));
-              should(data.headers['Content-Range']).equal(`bytes ${startByte}-${numberOfBytes}/${numberOfBytes}`);
+              should(data.headers['Content-Range']).equal(`bytes ${startByte}-${numberOfBytes}/${content.length}`);
               should(data.headers['Content-Length']).equal(content.length - startByte);
             })
         ));
@@ -305,7 +304,7 @@ describe('Browsing', () => {
       const content = `hello world, on ${Math.round(Math.random() * 100000)}`;
       return createRandomDomain(content, '/streaming.mp4')
         .then((domain) => createAnonTestApp()
-          .then((app) => should(app.webFetch(`safe://${domain}/streaming.mp4`, { range: { start: 0, end: content.length + 1 } }))
+          .then((app) => should(app.webFetch(`safe://${domain}/streaming.mp4`, { range: { start: 0, end: content.length } }))
             .be.rejectedWith('NFS error: Invalid byte range specified')
         ));
     }).timeout(20000);

--- a/test/browsing.js
+++ b/test/browsing.js
@@ -113,6 +113,16 @@ describe('Browsing', () => {
       ));
   }).timeout(20000);
 
+
+  it('fetch partial content', () => {
+    const content = `hello world, on ${Math.round(Math.random() * 100000)}`;
+    return createRandomDomain(content, '/yumyum.html', 'whatever.valid_service')
+      .then((domain) => createAnonTestApp()
+        .then((app) => app.webFetch(`safe://whatever.valid_service.${domain}/yumyum.html`, { range: { start: 0, end: 14 } })
+          .then((data) => should(data.body.toString()).equal(content.substring(0, 14)))
+      ));
+  }).timeout(20000);
+
   it('find private service', () => {
     const content = `hello world, on ${Math.round(Math.random() * 100000)}`;
     return createRandomPrivateServiceDomain(content, '/yumyum.html', 'www')

--- a/test/nfs.js
+++ b/test/nfs.js
@@ -98,7 +98,7 @@ describe('NFS emulation', () => {
         .then((file) => m.get('test.txt').then((value) => nfs.update('test.txt', file, value.version + 1)))
         .then(() => nfs.fetch('test.txt'))
         .then((file) => nfs.open(file, 4))
-        .then((f) => f.read(0, 0))
+        .then((f) => f.read(CONSTANTS.NFS_FILE_START, CONSTANTS.NFS_FILE_END))
         .then((co) => {
           should(co.toString()).be.equal('Hello world');
         })


### PR DESCRIPTION
in webfetch requests.

Enables `webfetch` to accept an object with `url` and `range` set (for example; as well as a simple string), range then being used to retrieve partial content from a `File`