### PR TITLE
chore/safe-app: Adapt code to upgrade safe-app lib to v0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     },
     "safe_app": {
       "mirror": "https://s3.eu-west-2.amazonaws.com/safe-client-libs",
-      "version": "v0.5.0",
+      "version": "v0.6.0",
       "targetDir": "src/native",
       "filename": "safe_app",
       "filePattern": "^.*\\.(dll|so|dylib)$",

--- a/src/native/_testing.js
+++ b/src/native/_testing.js
@@ -1,28 +1,15 @@
 
 const ref = require('ref');
-const { types: t } = require("./_base");
+const { types: t, helpers: h } = require("./_base");
+const { types } = require('./_auth');
 
 module.exports = {
   functions: {
-    test_create_app: [t.i32, [t.AppPtr]],
-    test_create_app_with_access: [t.i32 , ['pointer', t.usize, t.AppPtr]],
+    test_create_app: [t.Void, ['string', 'pointer', 'pointer']],
+    test_create_app_with_access: [t.Void, [ref.refType(types.AuthReq), 'pointer', 'pointer']],
   },
   api: {
-    test_create_app: (lib, fn) => {
-      return () => {
-        const appCon = ref.alloc(t.AppPtr);
-        const ret = fn(appCon);
-        if (ret) throw Error("Creating testing app failed: " + ret);
-        return appCon.deref();
-      }
-    },
-    test_create_app_with_access: (lib, fn) => {
-      return (permissions) => {
-        const appCon = ref.alloc(t.AppPtr);
-        const ret = fn(permissions.buffer, permissions.length, appCon);
-        if (ret) throw Error("Creating testing app failed: " + ret);
-        return appCon.deref();
-      }
-    }
+    test_create_app: h.Promisified(null, t.AppPtr),
+    test_create_app_with_access: h.Promisified(null, t.AppPtr),
   }
 }

--- a/test/app.js
+++ b/test/app.js
@@ -51,20 +51,20 @@ describe('Smoke test', () => {
         .then((resp) => should(resp.uri).startWith('safe-auth:'));
   });
 
-  it('creates registered for testing', () => {
-    const app = createAuthenticatedTestApp();
+  it('creates registered for testing', async () => {
+    const app = await createAuthenticatedTestApp();
     should(app.auth.registered).be.true();
   }).timeout(20000);
 
-  it('clears object cache invalidating objects', () => {
-    const app = createAuthenticatedTestApp();
-    return app.mutableData.newMutation()
+  it('clears object cache invalidating objects', () => createAuthenticatedTestApp()
+    .then((app) => app.mutableData.newMutation()
       .then((mut) => should(mut.insert('key1', 'value1')).be.fulfilled()
         .then(() => should(app.clearObjectCache()).be.fulfilled())
         .then(() => should(mut.insert('key2', 'value2')).be.rejectedWith('Invalid MutableData entry actions handle'))
       )
-      .then(() => should(app.mutableData.newMutation()).be.fulfilled());
-  }).timeout(20000);
+      .then(() => should(app.mutableData.newMutation()).be.fulfilled())
+    )
+  ).timeout(20000);
 
   it('validate is mock build', () => {
     const app = createTestApp();
@@ -108,13 +108,13 @@ describe('Smoke test', () => {
   });
 
   it('should return account information', async () => {
-    const app = createAuthenticatedTestApp();
+    const app = await createAuthenticatedTestApp();
     const accInfo = await app.getAccountInfo();
     should(accInfo).have.properties(['mutations_done', 'mutations_available']);
   }).timeout(10000);
 
   it('should increment/decrement mutation values', async () => {
-    const app = createAuthenticatedTestApp();
+    const app = await createAuthenticatedTestApp();
     const accInfoBefore = await app.getAccountInfo();
     const idWriter = await app.immutableData.create();
     const testString = `test-${Math.random()}`;
@@ -133,7 +133,7 @@ describe('Smoke test', () => {
   });
 
   it('returns safe_client_libs log path', async () => {
-    const app = createAuthenticatedTestApp();
+    const app = await createAuthenticatedTestApp();
     should(app.logPath()).be.fulfilled();
   }).timeout(10000);
 
@@ -141,8 +141,8 @@ describe('Smoke test', () => {
     should(h.App.fromAuthUri(h.appInfo, h.authUris.registeredUri)).be.fulfilled();
   });
 
-  it('returns boolean for network state', () => {
-    const app = createAuthenticatedTestApp();
+  it('returns boolean for network state', async () => {
+    const app = await createAuthenticatedTestApp();
     should(app.isNetStateInit()).be.true();
     should(app.isNetStateConnected()).be.false();
     should(app.isNetStateDisconnected()).be.false();

--- a/test/auth.js
+++ b/test/auth.js
@@ -5,8 +5,13 @@ const createAuthenticatedTestApp = h.createAuthenticatedTestApp;
 
 /* eslint-disable no-shadow */
 describe('auth interface', () => {
-  const containersPermissions = { _public: ['Read'], _publicNames: ['Read', 'Insert', 'ManagePermissions'] };
-  const app = createAuthenticatedTestApp('_test_scope', containersPermissions);
+  let app;
+
+  before(async () => {
+    const containersPermissions = { _public: ['Read'], _publicNames: ['Read', 'Insert', 'ManagePermissions'] };
+    app = await createAuthenticatedTestApp('_test_scope', containersPermissions);
+  });
+
   it('should build some authentication uri', () => {
     const app = h.createTestApp();
     return app.auth.genAuthUri({ _public: ['Read'] })
@@ -52,8 +57,12 @@ describe('auth interface', () => {
 });
 
 describe('Access Container', () => {
-  const containersPermissions = { _public: ['Read'], _publicNames: ['Read', 'Insert', 'ManagePermissions'] };
-  const app = createAuthenticatedTestApp('_test_scope', containersPermissions);
+  let app;
+
+  before(async () => {
+    const containersPermissions = { _public: ['Read'], _publicNames: ['Read', 'Insert', 'ManagePermissions'] };
+    app = await createAuthenticatedTestApp('_test_scope', containersPermissions, { own_container: true });
+  });
 
   it('should have a connection object after completing app authentication', () => {
     should.exist(app.connection);

--- a/test/browsing.js
+++ b/test/browsing.js
@@ -5,9 +5,9 @@ const consts = require('../src/consts');
 const createAnonTestApp = h.createAnonTestApp;
 const createAuthenticatedTestApp = h.createAuthenticatedTestApp;
 
-const createRandomDomain = (content, path, service, authedApp) => {
+const createRandomDomain = async (content, path, service, authedApp) => {
   const domain = `test_${Math.round(Math.random() * 100000)}`;
-  const app = authedApp || createAuthenticatedTestApp();
+  const app = authedApp || await createAuthenticatedTestApp();
   return app.mutableData.newRandomPublic(consts.TAG_TYPE_WWW)
     .then((serviceMdata) => serviceMdata.quickSetup()
       .then(() => {
@@ -28,9 +28,9 @@ const createRandomDomain = (content, path, service, authedApp) => {
 };
 
 
-const createRandomPrivateServiceDomain = (content, path, service) => {
+const createRandomPrivateServiceDomain = async (content, path, service) => {
   const domain = `test_${Math.round(Math.random() * 100000)}`;
-  const app = createAuthenticatedTestApp();
+  const app = await createAuthenticatedTestApp();
   return app.mutableData.newRandomPrivate(consts.TAG_TYPE_WWW)
     .then((serviceMdata) => serviceMdata.quickSetup()
       .then(() => {
@@ -346,8 +346,8 @@ describe('Browsing', () => {
         });
     });
 
-    it('should throw error when a previously existing service is removed', () => {
-      const app = createAuthenticatedTestApp();
+    it('should throw error when a previously existing service is removed', async () => {
+      const app = await createAuthenticatedTestApp();
       const deletedService = 'nonexistant';
       let testDomain;
       return createRandomDomain(content, '', deletedService, app)

--- a/test/cipher_opt.js
+++ b/test/cipher_opt.js
@@ -2,7 +2,11 @@ const should = require('should');
 const h = require('./helpers');
 
 describe('CipherOpt', () => {
-  const app = h.createAuthenticatedTestApp();
+  let app;
+
+  before(async () => {
+    app = await h.createAuthenticatedTestApp();
+  });
 
   it('provides a plain text cipher opt to write immutable structure', async () => {
     const testString = 'information to be encrypted';
@@ -27,7 +31,7 @@ describe('CipherOpt', () => {
   });
 
   it('asymmetrically encrypts data to be written to immutable structure', async () => {
-    const differentApp = h.createAltAuthTestApp();
+    const differentApp = await h.createAltAuthTestApp();
     const pubEncKey = await differentApp.crypto.getAppPubEncKey();
     const rawKey = await pubEncKey.getRaw();
 
@@ -42,4 +46,4 @@ describe('CipherOpt', () => {
     const idData = await idReader.read();
     should(idData.toString()).equal(testString);
   }).timeout(10000);
-}).timeout(15000);
+});

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -23,15 +23,14 @@ const createTestApp = (scope) =>
     scope
   }, null, { log: false }));
 
-const createAltAuthTestApp = (scope, access) => {
+const createAltAuthTestApp = async (scope, access) => {
   const app = h.autoref(new App({
     id: 'alt-net.maidsafe.test.javascript.id',
     name: 'alt-NodeJS Test',
     vendor: 'alt-MaidSafe.net Ltd',
     scope
   }, null, { log: false }));
-  app.auth.loginForTest(access || {}); // Promise, but immediate
-  return app;
+  return app.auth.loginForTest(access || {});
 };
 
 const createTestAppWithNetworkCB = (scope, networkCB) =>
@@ -55,10 +54,9 @@ const createAnonTestApp = (scope) => {
   return app.auth.loginForTest();
 };
 
-const createAuthenticatedTestApp = (scope, access) => {
+const createAuthenticatedTestApp = (scope, access, opts) => {
   const app = createTestApp(scope);
-  app.auth.loginForTest(access || {}); // Promise, but immediate
-  return app;
+  return app.auth.loginForTest(access || {}, opts);
 };
 
 const createRandomXorName = () => crypto.randomBytes(32);

--- a/test/immutable.js
+++ b/test/immutable.js
@@ -2,8 +2,12 @@ const should = require('should');
 const h = require('./helpers');
 
 describe('Immutable Data', () => {
-  const app = h.createAuthenticatedTestApp();
+  let app;
   const TYPE_TAG = 15639;
+
+  before(async () => {
+    app = await h.createAuthenticatedTestApp();
+  });
 
   it('returns Reader for corresponding operations', async () => {
     const testString = `test-${Math.random()}`;

--- a/test/mutable/entries_keys_values.js
+++ b/test/mutable/entries_keys_values.js
@@ -1,12 +1,15 @@
 const should = require('should');
 const h = require('../helpers');
 
-const createAuthenticatedTestApp = h.createAuthenticatedTestApp;
-
 describe('Mutable Data Entries', () => {
-  const app = createAuthenticatedTestApp();
+  let app;
   const TYPE_TAG = 15639;
   const TEST_ENTRIES = { key1: 'value1', key2: 'value2' };
+
+  before(async () => {
+    app = await h.createAuthenticatedTestApp();
+  });
+
 
   it('get entries and check length', () => app.mutableData.newRandomPublic(TYPE_TAG)
       .then((m) => m.quickSetup(TEST_ENTRIES).then(() => m.getEntries()))

--- a/test/mutable/index.js
+++ b/test/mutable/index.js
@@ -2,14 +2,16 @@ const should = require('should');
 const h = require('../helpers');
 const { pubConsts: CONSTANTS } = require('../../src/consts');
 
-const createAuthenticatedTestApp = h.createAuthenticatedTestApp;
-
 describe('Mutable Data', () => {
-  const app = createAuthenticatedTestApp();
+  let app;
   const TYPE_TAG = 15639;
   const TAG_TYPE_INVALID = '_invalid_tag';
   const TEST_NAME_INVALID = 'name-shorter-than-32-bytes-long';
   const TEST_ENTRIES = { key1: 'value1', key2: 'value2' };
+
+  before(async () => {
+    app = await h.createAuthenticatedTestApp();
+  });
 
   describe('Create with invalid values', () => {
     it('create random public with invalid tag vaue', () =>

--- a/test/mutable/mutation.js
+++ b/test/mutable/mutation.js
@@ -2,12 +2,14 @@ const crypto = require('crypto');
 const should = require('should');
 const h = require('../helpers');
 
-const createAuthenticatedTestApp = h.createAuthenticatedTestApp;
-
 describe('Applying EntryMutationTransaction', () => {
-  const app = createAuthenticatedTestApp();
+  let app;
   const TYPE_TAG = 15639;
   const TEST_ENTRIES = { key1: 'value1', key2: 'value2' };
+
+  before(async () => {
+    app = await h.createAuthenticatedTestApp();
+  });
 
   it('an insert mutation from existing entries', () => app.mutableData.newRandomPublic(TYPE_TAG)
       .then((m) => m.quickSetup(TEST_ENTRIES)

--- a/test/mutable/permissions.js
+++ b/test/mutable/permissions.js
@@ -2,12 +2,14 @@ const should = require('should');
 const h = require('../helpers');
 const { pubConsts: CONSTANTS } = require('../../src/consts');
 
-const createAuthenticatedTestApp = h.createAuthenticatedTestApp;
-
 describe('Permissions', () => {
-  const app = createAuthenticatedTestApp();
+  let app;
   const TYPE_TAG = 15639;
   const TEST_ENTRIES = { key1: 'value1', key2: 'value2' };
+
+  before(async () => {
+    app = await h.createAuthenticatedTestApp();
+  });
 
   it('get list of permissions', () => app.mutableData.newRandomPublic(TYPE_TAG)
       .then((m) => m.quickSetup(TEST_ENTRIES)

--- a/test/nfs.js
+++ b/test/nfs.js
@@ -2,11 +2,13 @@ const should = require('should');
 const h = require('./helpers');
 const { pubConsts: CONSTANTS } = require('../src/consts');
 
-const createAuthenticatedTestApp = h.createAuthenticatedTestApp;
-
 describe('NFS emulation', () => {
-  const app = createAuthenticatedTestApp();
+  let app;
   const TYPE_TAG = 15639;
+
+  before(async () => {
+    app = await h.createAuthenticatedTestApp();
+  });
 
   it('opens file in write mode, writes, and returns fetched file', () => app.mutableData.newRandomPublic(TYPE_TAG)
     .then((m) => m.quickSetup({}).then(() => m.emulateAs('nfs')))


### PR DESCRIPTION
The safe-app lib changed the signature for the test functions, i.e. `test_create_app` and `test_create_app_with_access`, also since they are now asynchronous functions our tests needed to be adapted.