### PR TITLE
MAID-2553 fix/systemuri: fix for passing empty URI string on Windows

### DIFF
--- a/src/native/_system_uri.js
+++ b/src/native/_system_uri.js
@@ -19,6 +19,7 @@ const makeError = require('./_error.js');
 const h = require('./helpers');
 const t = require('./types');
 const ArrayType = require('ref-array');
+const errConst = require('../error_const');
 
 const StringArray = ArrayType(ref.types.CString);
 
@@ -61,7 +62,10 @@ const openUri = (uri) => {
   return new Promise((resolve,  reject) => {
     try {
       const cb = _handleError(resolve,  reject);
-      ffi.open_uri(uri.uri || uri, ref.NULL, cb);
+      if (uri) {
+        ffi.open_uri(uri.uri || uri, ref.NULL, cb);
+      }
+      return reject(makeError(errConst.MISSING_URL.code, errConst.MISSING_URL.msg));
     } catch (err) {
       return reject(err);
     }

--- a/test/index.js
+++ b/test/index.js
@@ -69,6 +69,7 @@ describe('Smoke testing', () => {
   // when a URI with unregistered protocol is passed.
   // Until this is potentially resolved in `system_uri` lib, this test will exist
   // to highlight the difference.
+  // MAID-2553 was raised to solve this.
   it('openUri behaves differently, based on platform, when handling unregistered protocol', async () => {
     const app = await h.createTestApp();
     if (process.platform === 'win32') {

--- a/test/index.js
+++ b/test/index.js
@@ -65,29 +65,36 @@ describe('Smoke testing', () => {
     return should.exist(console.warn);
   });
 
-  it('system uri openUri function rejected when empty URL is passed', () => {
-    const app = h.createTestApp();
+  // TODO: openUri behaves differently on Windows than OSX or Linux,
+  // when a URI with unregistered protocol is passed.
+  // Until this is potentially resolved in `system_uri` lib, this test will exist
+  // to highlight the difference.
+  it('openUri behaves differently, based on platform, when handling unregistered protocol', async () => {
+    const app = await h.createTestApp();
+    if (process.platform === 'win32') {
+      // Why fulfilled? Because Windows opens a dialog for user to choose application
+      // to associate with unregistered protocol.
+      return should(app.auth.openUri('unregistered://resource')).be.fulfilled();
+    } else if (process.platform === 'linux') {
+      // Why fulfilled? Because Linux in Travis CI does not behave the same as on desktop env
+      return should(app.auth.openUri('unregistered://resource')).be.fulfilled();
+    }
+    return should(app.auth.openUri('unregistered://resource')).be.rejected();
+  });
+
+  it('system uri openUri function rejected when empty string URL is passed', async () => {
+    const app = await h.createTestApp();
     return should(app.auth.openUri('')).be.rejectedWith(errConst.MISSING_URL.msg);
   });
 
-  it('system uri openUri function rejected when no URL is passed', () => {
-    const app = h.createTestApp();
+  it('system uri openUri function rejected when no URL is passed', async () => {
+    const app = await h.createTestApp();
     return should(app.auth.openUri()).be.rejected();
   });
 
-  it('system uri openUri function rejected when URL string as blankspace is passed', () => {
-    const app = h.createTestApp();
+  it('system uri openUri function rejected when URL string as blankspace is passed', async () => {
+    const app = await h.createTestApp();
     return should(app.auth.openUri(' ')).be.rejected();
-  });
-
-  it('system uri openUri function rejected when null URL is passed', () => {
-    const app = h.createTestApp();
-    return should(app.auth.openUri(null)).be.rejected();
-  });
-
-  it('system uri openUri function rejected when undefined URL is passed', () => {
-    const app = h.createTestApp();
-    return should(app.auth.openUri(undefined)).be.rejected();
   });
 
   it('system uri lib contains "mock" dir (as we\'re testing)', () => {

--- a/test/index.js
+++ b/test/index.js
@@ -65,15 +65,29 @@ describe('Smoke testing', () => {
     return should.exist(console.warn);
   });
 
-  // TODO: there is an inconsistency between Linux and Windows
-  // for the `openUri` function behaviour.
-  // On Linux the promise is rejected as expected, while on Windows
-  // the promise is resolved with an undefined value. We need to research
-  // where the issue exactly is, i.e. system_uri lib or safe_app_nodejs.
-  // MAID-2553 was raised to solve this.
-  it('system uri openUri function returns a promise', async () => {
-    const app = await h.createTestApp();
-    return should(app.auth.openUri('')).be.a.Promise(); // TODO: when isse fix add ``.and.be.rejected()` to remove the warning
+  it('system uri openUri function rejected when empty URL is passed', () => {
+    const app = h.createTestApp();
+    return should(app.auth.openUri('')).be.rejectedWith(errConst.MISSING_URL.msg);
+  });
+
+  it('system uri openUri function rejected when no URL is passed', () => {
+    const app = h.createTestApp();
+    return should(app.auth.openUri()).be.rejected();
+  });
+
+  it('system uri openUri function rejected when URL string as blankspace is passed', () => {
+    const app = h.createTestApp();
+    return should(app.auth.openUri(' ')).be.rejected();
+  });
+
+  it('system uri openUri function rejected when null URL is passed', () => {
+    const app = h.createTestApp();
+    return should(app.auth.openUri(null)).be.rejected();
+  });
+
+  it('system uri openUri function rejected when undefined URL is passed', () => {
+    const app = h.createTestApp();
+    return should(app.auth.openUri(undefined)).be.rejected();
   });
 
   it('system uri lib contains "mock" dir (as we\'re testing)', () => {


### PR DESCRIPTION
When an empty string, `''` (ASCII 00), is passed to our `system_uri` `openURI` on Windows and on OSX, file explorer is opened and promise is resolved, which differs on Linux where the result is a rejected promise. What ultimately gets passed to `ShellExecute`'s [lpFile](https://github.com/maidsafe/system_uri/blob/master/src/windows.rs#L37) property is `[0]`.

I built a local `system_uri` dll, where I passed `ptr::null()` to `lpFile` and even that produced the same file explorer behavior.
I also tried passing an empty `Vec` to `lpFile`, [seen here](https://github.com/hunterlester/system_uri/blob/test/src/windows.rs#L28), which causes a crash with very generic error name and code, respectively, `ELIFECYCLE` and `3221225477`. cc: @nbaksalyar 

The simple solution in this library is only call native `open_uri` if URI is provided, although the downside is that any other library utilizing `system_uri` on Windows would also have to handle this minor bug as well.