### PR TITLE
MAID-2414 feat/systemuri: add config option to disable system URI operations

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -3,6 +3,7 @@
 [Unreleased]
 ### Added
 - New binding `simulateNetworkDisconnect()` function to simulate a network disconnection event useful for applications testing purposes.
+- Ability to prevent system_uri from downloading by setting environment variable
 
 ### Changed
 - Upgrade safe_app native library to commit `a9b4c05` and adapt to minor API changes

--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ To run the tests locally, make sure you installed the [`safe_app`](https://githu
 
 Note: If you are compiling your own [`safe_app`](https://github.com/maidsafe/safe_client_libs/tree/master/safe_app) library for testing purposes, and if you want to be able to run the tests, make sure to include `testing` in your build features when compiling `safe_app` in `safe_client_libs`, i.e. `cargo build --release --features "use-mock-routing testing"`.
 
+### Mobile Development
+If you do not require the [system_uri](https://github.com/maidsafe/system_uri) and would like to prevent it from downloading, first set the `DISABLE_SAFE_SYSTEM_URI=true` environment variable before running `yarn`.
+
 ## Further Help
 
 You can discuss development-related questions on the [SAFE Dev Forum](https://forum.safedev.org/).

--- a/disable-system-uri.json
+++ b/disable-system-uri.json
@@ -1,0 +1,20 @@
+{
+  "download_deps": {
+    "safe_app": {
+      "mirror": "https://s3.eu-west-2.amazonaws.com/safe-client-libs",
+      "version": "a9b4c05",
+      "targetDir": "src/native/prod",
+      "filename": "safe_app",
+      "filePattern": "^.*\\.(dll|so|dylib)$",
+      "force": true
+    },
+    "ENV": {
+      "dev": {
+        "safe_app": {
+          "targetDir": "src/native/mock",
+          "filename": "safe_app-mock"
+        }
+      }
+    }
+  }
+}

--- a/install-dev-libs.js
+++ b/install-dev-libs.js
@@ -4,10 +4,17 @@ const { spawn } = require('child_process');
 const env = process.env.NODE_ENV || 'production';
 
 const isRunningDevelopment = /^dev/.test(env);
+const disableSystemUri = process.env.DISABLE_SAFE_SYSTEM_URI || false;
+const spawnArgs = ['run', 'install-mock', '--package'];
+if (disableSystemUri) {
+  spawnArgs.push('disable-system-uri.json');
+} else {
+  spawnArgs.push('package.json');
+}
 
 if (isRunningDevelopment) {
   spawn(
     'yarn',
-    ['run', 'install-mock'],
+    spawnArgs,
     { shell: true, env: process.env, stdio: 'inherit' });
 }

--- a/install-prod-libs.js
+++ b/install-prod-libs.js
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+const { spawn } = require('child_process');
+
+const disableSystemUri = process.env.DISABLE_SAFE_SYSTEM_URI || false;
+const spawnArgs = ['run', 'install-prod', '--package'];
+if (disableSystemUri) {
+  spawnArgs.push('disable-system-uri.json');
+} else {
+  spawnArgs.push('package.json');
+}
+
+spawn(
+  'yarn',
+  spawnArgs,
+  { shell: true, env: process.env, stdio: 'inherit' });

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "scripts": {
     "lint": "eslint src test",
     "fix-lint": "eslint --fix src test",
-    "postinstall": "npm run install-prod && node install-dev-libs.js",
-    "install-prod": "cross-env NODE_ENV=prod download_deps --package package.json",
-    "install-mock": "cross-env NODE_ENV=dev download_deps --package package.json",
+    "postinstall": "node install-prod-libs.js && node install-dev-libs.js",
+    "install-prod": "cross-env NODE_ENV=prod download_deps",
+    "install-mock": "cross-env NODE_ENV=dev download_deps",
     "docs": "documentation build --config etc/documentation.yml --github true --output docs --format html src/**",
     "serve-docs": "documentation serve --config etc/documentation.yml --github true --output docs --format html src/**",
     "test": "mocha --recursive",

--- a/src/native/lib.js
+++ b/src/native/lib.js
@@ -26,6 +26,7 @@ const ffi = {};
 const RTLD_NOW = FFI.DynamicLibrary.FLAGS.RTLD_NOW;
 const RTLD_GLOBAL = FFI.DynamicLibrary.FLAGS.RTLD_GLOBAL;
 const mode = RTLD_NOW | RTLD_GLOBAL;
+const disableSystemUri = process.env.DISABLE_SAFE_SYSTEM_URI;
 let lib = null;
 
 ffi.init = (options) => {
@@ -65,9 +66,10 @@ ffi.init = (options) => {
     // FIXME: As long as `safe-app` doesn't expose system uri itself, we'll
     // patch it directly on it. This should later move into its own sub-module
     // and take care of mobile support for other platforms, too.
-    require('./_system_uri')(ffi, options);
+    if (!disableSystemUri) {
+      require('./_system_uri')(ffi, options);
+    }
   } catch(e) {
-    console.error("ERROR: ", e)
     throw makeError(errConst.FAILED_TO_LOAD_LIB.code,
         errConst.FAILED_TO_LOAD_LIB.msg(e.toString()));
   }

--- a/test/index.js
+++ b/test/index.js
@@ -65,6 +65,10 @@ describe('Smoke testing', () => {
     return should.exist(console.warn);
   });
 
+  it('it fails to load invalid lib path', () => should(
+    h.createTestAppWithOptions(null, { libPath: 'invalid lib path' }))
+      .be.rejectedWith(errConst.FAILED_TO_LOAD_LIB.code));
+
   // TODO: there is an inconsistency between Linux and Windows
   // for the `openUri` function behaviour.
   // On Linux the promise is rejected as expected, while on Windows


### PR DESCRIPTION
Do we also want to prevent `system_uri.(dll|so|dylib)` from downloading?

Currently working on this being an app initialization option, however, it is preferable to have a CLI flag, like `--mock`?