### PR TITLE
MAID-2877 fix/validation: Improves error handling for malformed appInfo object passed to initialiseApp

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -27,6 +27,7 @@
 ### Fixed
 - Fixed some tests which were giving false positive results
 - Added missing error handling for `app_reconnect` to prevent false connection status
+- Error handling for malformed appInfo object passed to initialiseApp
 
 ## SAFE libraries Dependencies
 - safe_app: v0.8.0

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,5 +1,16 @@
 # safe_app nodejs Change Log
 
+[Unreleased]
+### Added
+
+### Changed
+
+### Fixed
+- Error handling for malformed appInfo object passed to initialiseApp
+
+## SAFE libraries Dependencies
+
+
 [0.9.0] - 27-7-2018
 ### Added
 - New binding `simulateNetworkDisconnect()` function to simulate a network disconnection event useful for applications testing purposes.
@@ -27,7 +38,6 @@
 ### Fixed
 - Fixed some tests which were giving false positive results
 - Added missing error handling for `app_reconnect` to prevent false connection status
-- Error handling for malformed appInfo object passed to initialiseApp
 
 ## SAFE libraries Dependencies
 - safe_app: v0.8.0

--- a/src/app.js
+++ b/src/app.js
@@ -26,14 +26,13 @@ const { webFetch } = require('./web_fetch.js');
 const validateAppInfo = (_appInfo) => {
   const appInfo = _appInfo;
   const appInfoMustHaveProperties = ['id', 'name', 'vendor'];
-  let bool = false;
   const hasCorrectProperties = appInfoMustHaveProperties.every((prop) => {
     if (appInfo && appInfo[prop]) {
       appInfo[prop] = appInfo[prop].trim();
-      bool = Object.prototype.hasOwnProperty.call(appInfo, prop) && appInfo[prop];
+      return Object.prototype.hasOwnProperty.call(appInfo, prop) && appInfo[prop];
     }
 
-    return bool;
+    return false;
   });
 
   if (!hasCorrectProperties) {

--- a/src/native/_app.js
+++ b/src/native/_app.js
@@ -20,6 +20,7 @@ const { helpersForNative } = require('./_auth.js');
 const { types } = require('./_auth');
 const AuthGranted = types.AuthGranted;
 const consts = require('../consts');
+const errConst = require('../error_const');
 
 const AccountInfo = Struct({
   mutations_done: t.u64,

--- a/test/auth.js
+++ b/test/auth.js
@@ -14,6 +14,7 @@
 const should = require('should');
 const h = require('./helpers');
 const errConst = require('../src/error_const');
+const lib = require('../src/native/lib');
 
 const createAuthenticatedTestApp = h.createAuthenticatedTestApp;
 const createTestApp = h.createTestApp;
@@ -139,6 +140,11 @@ describe('auth interface', () => {
         should(resp.uri).is.not.undefined();
         return should(resp.uri).startWith('safe-auth:');
       });
+  });
+
+  it('throws error if no URI provided to app_unregistered', async () => {
+    const app = await createTestApp();
+    return should(lib.app_unregistered(app)).be.rejectedWith(errConst.MISSING_AUTH_URI.msg);
   });
 
   it('logs in to network with URI response from authenticator', async () => {

--- a/test/index.js
+++ b/test/index.js
@@ -136,6 +136,8 @@ describe('External API', () => {
       const wrongAppInfo = Object.assign({}, appInfo, { customExecPath: 'non-array-exec-path' });
       return should(initialiseApp(wrongAppInfo)).be.rejectedWith('Exec command must be an array of string arguments');
     });
+
+    it('throws error for appInfo property', () => should(initialiseApp({ id: 'id1', vendor: 'vendor' })).be.rejected());
   });
 
   describe('fromAuthUri', () => {

--- a/test/index.js
+++ b/test/index.js
@@ -137,7 +137,7 @@ describe('External API', () => {
       return should(initialiseApp(wrongAppInfo)).be.rejectedWith('Exec command must be an array of string arguments');
     });
 
-    it('throws error for appInfo property', () => should(initialiseApp({ id: 'id1', vendor: 'vendor' })).be.rejected());
+    it('throws error for missing appInfo property', () => should(initialiseApp({ id: 'id1', vendor: 'vendor' })).be.rejectedWith(errConst.MALFORMED_APP_INFO.msg));
   });
 
   describe('fromAuthUri', () => {


### PR DESCRIPTION
Currently, no errors are thrown on `initialiseApp` if a info object is passed, but if name (for eg) is `undefined`, it does not throw a useful error (but genAuthUri will die in an obscure fashion).

We should throw more helpful errors for object malformation.

```
info :

{ id : 'somthing, scope : null, name : undefined, vendor : 'something else' }
```