### PR TITLE
Change docs to reflect testing condition loginForTest and simulateNetworkDisconnect

### DIFF
--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -375,7 +375,7 @@ class AuthInterface {
   }
 
   /**
-  * *ONLY AVAILALBE IF RUN in NODE_ENV='testing' OR WITH 'forceUseMock' option*
+  * *ONLY AVAILALBE IF RUN in NODE_ENV='test' OR WITH 'forceUseMock' option*
   *
   * Generate a _locally_ registered App with the given permissions, or
   * a local unregistered App if permissions is `null`.
@@ -412,7 +412,7 @@ class AuthInterface {
   }
 
   /**
-  * *ONLY AVAILALBE IF RUN in NODE_ENV='testing' OR WITH 'forceUseMock' option*
+  * *ONLY AVAILALBE IF RUN in NODE_ENV='test' OR WITH 'forceUseMock' option*
   *
   * Simulates a network disconnection event. This can be used to
   * test any logic to be executed by an application when a network

--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -375,7 +375,7 @@ class AuthInterface {
   }
 
   /**
-  * *ONLY AVAILALBE IF RUN in NODE_ENV='development' || 'testing'*
+  * *ONLY AVAILALBE IF RUN in NODE_ENV='testing' OR WITH 'forceUseMock' option*
   *
   * Generate a _locally_ registered App with the given permissions, or
   * a local unregistered App if permissions is `null`.
@@ -412,7 +412,7 @@ class AuthInterface {
   }
 
   /**
-  * *ONLY AVAILALBE IF RUN in NODE_ENV='development' || 'testing'*
+  * *ONLY AVAILALBE IF RUN in NODE_ENV='testing' OR WITH 'forceUseMock' option*
   *
   * Simulates a network disconnection event. This can be used to
   * test any logic to be executed by an application when a network

--- a/src/error_const.js
+++ b/src/error_const.js
@@ -228,7 +228,7 @@ module.exports = {
     code: 1012,
     msg: `
     Not supported outside of Testing Environment.
-    Set NODE_ENV=testing`
+    Set NODE_ENV=test`
   },
 
   /**

--- a/src/error_const.js
+++ b/src/error_const.js
@@ -227,8 +227,8 @@ module.exports = {
   NON_DEV: {
     code: 1012,
     msg: `
-    Not supported outside of Dev and Testing Environment.
-    Set NODE_ENV=dev`
+    Not supported outside of Testing Environment.
+    Set NODE_ENV=testing`
   },
 
   /**


### PR DESCRIPTION
`useMockByDefault` is based only on `NODE_ENV` being `testing`. Can be influenced by `forceUseMock` too.