### PR TITLE
docs/README: Add instructions to the README for how to generate API docs locally

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,5 +1,17 @@
 # safe_app nodejs Change Log
 
+[Unreleased]
+### Added
+- Add instructions to the README for how to generate API docs locally
+
+### Fixed
+- Change docs to reflect testing condition for `loginForTest` and `simulateNetworkDisconnect` functions.
+
+## SAFE libraries Dependencies
+- safe_app: v0.8.0
+- system_uri: v0.4.0
+- deps_downloader: v0.2.0
+
 [0.9.1] - 27-8-2018
 ### Added
 - Error handling for malformed `appInfo` object passed to `initialiseApp` (issue #257)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A safe_app library for [Node.js](https://nodejs.org/).
 
 ## API Documentation
 
-The documentation for the safe_app Node.js API is available at <http://docs.maidsafe.net/safe_app_nodejs/>.
+The documentation for the latest `safe_app_nodejs` API is available at <http://docs.maidsafe.net/safe_app_nodejs/>. See the ['Generate API docs' section](#generate-api-docs) further down for instructions to generate this docs locally.
 
 ## Development
 
@@ -48,12 +48,21 @@ To run the tests locally, make sure you installed the [`safe_app`](https://githu
 Note: If you are compiling your own [`safe_app`](https://github.com/maidsafe/safe_client_libs/tree/master/safe_app) library for testing purposes, and if you want to be able to run the tests, make sure to include `testing` in your build features when compiling `safe_app` in `safe_client_libs`, i.e. `cargo build --release --features "use-mock-routing testing"`.
 
 ### Mobile Development
+
 If you do not require [system_uri](https://github.com/maidsafe/system_uri) and would like to prevent it from downloading, first set `NODE_ENV` environment variable to either `mobile_prod` or `mobile_dev` before running `yarn`.
+
+### Generate API docs
+
+The documentation for the latest `safe_app_nodejs` API is published at <http://docs.maidsafe.net/safe_app_nodejs/>. If you are otherwise using a previous version of this package, you can also generate the API docs locally. Make sure you first install this package's dependencies with `yarn`, then execute the following command:
+```bash
+yarn docs
+```
+The API docs will be generated under the `docs` folder, you can simply open the `docs/index.html` file with your default browser.
 
 ## Further Help
 
 You can discuss development-related questions on the [SAFE Dev Forum](https://forum.safedev.org/).
-Here's a good post to get started: [How to develop for the SAFE Network](https://forum.safedev.org/t/how-to-develop-for-the-safe-network-draft/843).
+If you are just starting to develop an application for the SAFE Network, it's very advisable to visit the [SAFE Network Dev Hub](https://hub.safedev.org) where you will find a lot of relevant information, including a [tutorial to create an example SAFE desktop application](https://hub.safedev.org/platform/nodejs) which makes use of this package.
 
 ## License
 


### PR DESCRIPTION
Resolves #285 