### PR TITLE
feat/API: Support for exposing experimental APIs with arg '--enable-experimental-apis' or 'enableExperimentalApis' initialisation flag

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -3,6 +3,7 @@
 [Unreleased]
 ### Added
 - Add instructions to the README for how to generate API docs locally
+- Support for exposing experimental APIs when `--enable-experimental-apis` argument is passed, or when `enableExperimentalApis` flag is set in the initialisation option
 
 ### Fixed
 - Change docs to reflect testing condition for `loginForTest` and `simulateNetworkDisconnect` functions.

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,6 +1,6 @@
 # safe_app nodejs Change Log
 
-[Unreleased]
+## [Unreleased]
 ### Added
 - Add instructions to the README for how to generate API docs locally
 - Support for exposing experimental APIs when `--enable-experimental-apis` argument is passed, or when `enableExperimentalApis` flag is set in the initialisation option
@@ -8,24 +8,24 @@
 ### Fixed
 - Change docs to reflect testing condition for `loginForTest` and `simulateNetworkDisconnect` functions.
 
-## SAFE libraries Dependencies
+### SAFE libraries Dependencies
 - safe_app: v0.8.0
 - system_uri: v0.4.0
 - deps_downloader: v0.2.0
 
-[0.9.1] - 27-8-2018
+## [0.9.1] - 27-8-2018
 ### Added
 - Error handling for malformed `appInfo` object passed to `initialiseApp` (issue #257)
 
 ### Fixed
 - Error "invalid utf-8: corrupt contents" fixed by preventing allocated CString reference from being reassigned to a corrupted value (issue #258)
 
-## SAFE libraries Dependencies
+### SAFE libraries Dependencies
 - safe_app: v0.8.0
 - system_uri: v0.4.0
 - deps_downloader: v0.2.0
 
-[0.9.0] - 27-7-2018
+## [0.9.0] - 27-7-2018
 ### Added
 - New binding `simulateNetworkDisconnect()` function to simulate a network disconnection event useful for applications testing purposes.
 - Support for forcing the use of mock by providing `forceUseMock` boolean to the initialisation options of each safeApp instance, i.e. each safeApp instance can either use mock or prod libs independently.
@@ -53,7 +53,7 @@
 - Fixed some tests which were giving false positive results
 - Added missing error handling for `app_reconnect` to prevent false connection status
 
-## SAFE libraries Dependencies
+### SAFE libraries Dependencies
 - safe_app: v0.8.0
 - system_uri: v0.4.0
 - deps_downloader: v0.2.0
@@ -100,7 +100,7 @@
 - system_uri: v0.4.0
 
 ## [0.6.1] - 18-1-2018
-## Changed
+### Changed
 - Recommend Node ^8.0.0 for building from source
 - Upgrade CI scripts to test Node 8.0.0
 - Pass the system URI's execution path as an array of arguments to support white spaces in it

--- a/README.md
+++ b/README.md
@@ -59,6 +59,26 @@ yarn docs
 ```
 The API docs will be generated under the `docs` folder, you can simply open the `docs/index.html` file with your default browser.
 
+### Experimental APIs
+
+You are free to use any of the experimental APIs to explore the features that are being actively designed and developed.
+
+Although you should be aware of the fact that all/any of the experimental APIs may be changed, deprecated, or even removed in the future, and without much anticipated notification by the core developers.
+
+The reason they are exposed is to just allow developers to experiment and start learning about the APIs at an early stage.
+
+In order to enable the experimental APIs the `--enable-experimental-apis` flag needs to be provided when running the application that depends on this package, or alternatively, the `enableExperimentalApis` flag can be set to true in the initialisation options.
+
+When any of the experimental APIs is called by an application, a warning message like the following will be logged in the console:
+```
+** Experimental API WARNING **
+* The application is making use of a safe-node-app experimental API *
+The '<function name>' function is part of a set of experimental functions.
+Any/all of them may be deprecated, removed, or very likely change in the future.
+Also regular users won't have this APIs enabled by default unless the flag is provided, so be aware of all these limitations.
+For more information, updates, or to submit ideas and suggestions, please visit https://github.com/maidsafe/safe_app_nodejs
+```
+
 ## Further Help
 
 You can discuss development-related questions on the [SAFE Dev Forum](https://forum.safedev.org/).

--- a/src/app.js
+++ b/src/app.js
@@ -18,7 +18,7 @@ const lib = require('./native/lib');
 const consts = require('./consts');
 const errConst = require('./error_const');
 const makeError = require('./native/_error.js');
-const { webFetch } = require('./web_fetch.js');
+const { webFetch, fetch } = require('./web_fetch.js');
 
 /**
 * Validates appInfo and properly handles error
@@ -94,11 +94,16 @@ class SAFEApp extends EventEmitter {
       log: true,
       registerScheme: true,
       configPath: null,
-      forceUseMock: false
+      forceUseMock: false,
+      enableExperimentalApis: false,
     }, options);
 
     if (typeof this.options.forceUseMock !== 'boolean') {
       throw new Error('The \'forceUseMock\' option must be a boolean.');
+    }
+
+    if (typeof this.options.enableExperimentalApis !== 'boolean') {
+      throw new Error('The \'enableExperimentalApis\' option must be a boolean.');
     }
 
     lib.init(this.options);
@@ -161,6 +166,10 @@ class SAFEApp extends EventEmitter {
 
   webFetch(url, options) {
     return webFetch.call(this, url, options);
+  }
+
+  fetch(url) {
+    return fetch.call(this, url);
   }
 
   /**

--- a/src/error_const.js
+++ b/src/error_const.js
@@ -335,5 +335,21 @@ module.exports = {
   INVALID_SEC_KEY: {
     code: 1020,
     msg: (size) => `Secret encryption key _must be_ provided and ${size} bytes long.`
-  }
+  },
+
+  /**
+   * @name EXPERIMENTAL_API_DISABLED
+   * @type {object}
+   * @description Thrown when functions that are experimental APIs were
+   * not enabled but attempted to be used
+   * @property {number} code 1021
+   * @property {string} msg
+   */
+  EXPERIMENTAL_API_DISABLED: {
+    code: 1021,
+    msg: (fn) => `
+    The '${fn}' function is disabled as it's part of the set of experimental APIs.
+    Pass --enable-experimental-apis argument to the application, or programatically
+    set the 'enableExperimentalApis' flag in the initialisation options to enable them.`
+  },
 };

--- a/src/index.js
+++ b/src/index.js
@@ -32,9 +32,9 @@ const { pubConsts: CONSTANTS } = require('./consts.js');
 /**
 * @typedef {Object} InitOptions
 * holds the additional intialisation options for the App.
-* @param {Boolean=} registerScheme to register auth scheme with the OS. Defaults to true
+* @param {Boolean=} registerScheme to register auth scheme with the OS. Defaults to true.
 * @param {Array=} joinSchemes to additionally register custom protocol schemes
-* @param {Boolean=} log to enable or disable back end logging. Defaults to true
+* @param {Boolean=} log to enable or disable back end logging. Defaults to true.
 * @param {String=} libPath path to the folder where the native libs can
 *        be found. Defaults to current folder path.
 * @param {String=} configPath set additional search path for the config files.
@@ -42,7 +42,10 @@ const { pubConsts: CONSTANTS } = require('./consts.js');
 *        in the same folder where the native library is, but also in this
 *        additional search path.
 * @param {Boolean=} forceUseMock to force the use of mock routing regardless
-*        the NODE_ENV environment variable value. Defaults to false
+*        the NODE_ENV environment variable value. Defaults to false.
+* @param {Boolean=} enableExperimentalApis to enable the experimental APIs
+*        regardless if the --enable-experimental-apis flag was passed as argument
+*        to the application. Defaults to false.
 */
 
 /**

--- a/src/web_fetch.js
+++ b/src/web_fetch.js
@@ -4,6 +4,7 @@ const makeError = require('./native/_error.js');
 const { parse: parseUrl } = require('url');
 const mime = require('mime');
 const nodePath = require('path');
+const { EXPOSE_AS_EXPERIMENTAL_API } = require('./helpers');
 
 // Helper function to read fetch the Container
 // from a public ID and service name provided
@@ -157,6 +158,21 @@ const readContentFromFile = async (openedFile, defaultMimeType, opts) => {
 };
 
 /**
+* Helper to lookup a given `safe://`-url in accordance with the
+* convention and find the requested object.
+*
+* @param {String} url the url you want to fetch
+* @returns {Promise<Object>} the native object
+*/
+async function fetch(url) {
+  /* eslint-disable no-shadow, prefer-arrow-callback */
+  return EXPOSE_AS_EXPERIMENTAL_API.call(this, async function fetch() {
+    // implementation of fetch function goes here
+    return url;
+  });
+}
+
+/**
 * @typedef {Object} WebFetchOptions
 * holds additional options for the `webFetch` function.
 * @param {Object} range range of bytes to be retrieved.
@@ -215,6 +231,7 @@ async function webFetch(url, options) {
 }
 
 module.exports = {
+  fetch,
   webFetch,
   getContainerFromPublicId,
   tryDifferentPaths,

--- a/test/app.js
+++ b/test/app.js
@@ -76,6 +76,7 @@ describe('Smoke test', () => {
       joinSchemes: ['proto'],
       configPath: '/home',
       forceUseMock: false,
+      enableExperimentalApis: false,
     };
     const app = await createTestApp(null, null, optionsObject);
 
@@ -104,6 +105,13 @@ describe('Smoke test', () => {
       forceUseMock: 'true' // this is expected to be a boolean
     }));
     should(test).throw("The 'forceUseMock' option must be a boolean.");
+  });
+
+  it('throw error if options object contains non-boolean enableExperimentalApis value', () => {
+    const test = () => autoref(new App(h.appInfo, null, {
+      enableExperimentalApis: 'true' // this is expected to be a boolean
+    }));
+    should(test).throw("The 'enableExperimentalApis' option must be a boolean.");
   });
 
   it('creates registered for testing', () => should(app.auth.registered).be.true());

--- a/test/auth.js
+++ b/test/auth.js
@@ -25,7 +25,7 @@ const containersPermissions = { _public: ['Read'], _publicNames: ['Read', 'Inser
 describe('auth interface', () => {
   let app;
   before(async () => {
-    app = await createAuthenticatedTestApp('_test_scope', containersPermissions);
+    app = await createAuthenticatedTestApp({ scope: '_test_scope' }, containersPermissions);
   });
 
   it('should build some authentication uri', async () => {
@@ -51,7 +51,7 @@ describe('auth interface', () => {
       _public: ['Insert', 'Read', 'Update'],
       _second: ['Read']
     };
-    return should(createAuthenticatedTestApp('_test_scope', containersPermissions, { own_container: true }))
+    return should(createAuthenticatedTestApp({ scope: '_test_scope' }, containersPermissions, { own_container: true }))
       .be.rejectedWith("'_second' not found in the access container");
   });
 
@@ -207,7 +207,7 @@ describe('Access Container', () => {
   const containersPermissions = { _public: ['Read'], _publicNames: ['Read', 'Insert', 'ManagePermissions'] };
 
   before(async () => {
-    app = await createAuthenticatedTestApp('_test_scope', containersPermissions, { own_container: true });
+    app = await createAuthenticatedTestApp({ scope: '_test_scope' }, containersPermissions, { own_container: true });
   });
 
   it('should have a connection object after completing app authentication', () => should.exist(app.connection));

--- a/test/browsing.js
+++ b/test/browsing.js
@@ -91,15 +91,13 @@ describe('Browsing', () => {
   let app;
   let unregisteredApp;
   before(async () => {
-    app = await createAuthenticatedTestApp('_test_scope', containersPermissions);
+    app = await createAuthenticatedTestApp({ scope: '_test_scope' }, containersPermissions);
     unregisteredApp = await createUnregisteredTestApp();
   });
 
-  it('returns rejected promise if no url is provided', () => {
-    const content = `hello world, on ${Math.round(Math.random() * 100000)}`;
-    return createRandomDomain(content, '', '', app)
-      .then(() => should(unregisteredApp.webFetch()).be.rejectedWith(errConst.MISSING_URL.msg));
-  });
+  it('returns rejected promise if no url is provided', () =>
+    should(unregisteredApp.webFetch()).be.rejectedWith(errConst.MISSING_URL.msg)
+  );
 
   it('fetch content', () => {
     const content = `hello world, on ${Math.round(Math.random() * 100000)}`;

--- a/test/experimental_apis/fetch.js
+++ b/test/experimental_apis/fetch.js
@@ -1,0 +1,91 @@
+// Copyright 2018 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under
+// the MIT license <LICENSE-MIT or http://opensource.org/licenses/MIT> or
+// the Modified BSD license <LICENSE-BSD or https://opensource.org/licenses/BSD-3-Clause>,
+// at your option.
+//
+// This file may not be copied, modified, or distributed except according to those terms.
+//
+// Please review the Licences for the specific language governing permissions and limitations
+// relating to use of the SAFE Network Software.
+
+
+const should = require('should');
+const h = require('../helpers');
+const consts = require('../../src/consts');
+
+const createAuthenticatedTestApp = h.createAuthenticatedTestApp;
+const createUnregisteredTestApp = h.createUnregisteredTestApp;
+
+const createRandomDomain = async (content, path, service, authedApp) => {
+  const domain = `test_${Math.round(Math.random() * 100000)}`;
+  const app = authedApp || await createAuthenticatedTestApp();
+  return app.mutableData.newRandomPublic(consts.TAG_TYPE_WWW)
+    .then((serviceMdata) => serviceMdata.quickSetup()
+      .then(() => {
+        const nfs = serviceMdata.emulateAs('NFS');
+        // let's write the file
+        return nfs.create(content)
+          .then((file) => nfs.insert(path || '/index.html', file))
+          .then(() => app.crypto.sha3Hash(domain)
+            .then((dnsName) => app.mutableData.newPublic(dnsName, consts.TAG_TYPE_DNS)
+              .then((dnsData) => serviceMdata.getNameAndTag()
+                  .then((res) => {
+                    const payload = {};
+                    payload[service || 'www'] = res.name;
+                    return dnsData.quickSetup(payload);
+                  }))));
+      }))
+    .then(() => domain);
+};
+
+const createRandomPrivateServiceDomain = async (content, path, service, authedApp) => {
+  const domain = `test_${Math.round(Math.random() * 100000)}`;
+  const app = authedApp || await createAuthenticatedTestApp();
+  return app.mutableData.newRandomPrivate(consts.TAG_TYPE_WWW)
+    .then((serviceMdata) => serviceMdata.quickSetup()
+      .then(() => {
+        const nfs = serviceMdata.emulateAs('NFS');
+        // let's write the file
+        return nfs.create(content)
+          .then((file) => nfs.insert(path || '', file))
+          .then(() => app.crypto.sha3Hash(domain)
+            .then((dnsName) => app.mutableData.newPublic(dnsName, consts.TAG_TYPE_DNS))
+              .then((dnsData) => serviceMdata.serialise()
+                  .then((serial) => {
+                    const payload = {};
+                    payload[service || ''] = serial;
+                    return dnsData.quickSetup(payload);
+                  })));
+      }))
+    .then(() => domain);
+};
+
+const containersPermissions = { _public: ['Read'], _publicNames: ['Read', 'Insert', 'ManagePermissions'] };
+
+describe('Fetching native objects', () => {
+  let app;
+  let unregisteredApp;
+  before(async () => {
+    app = await createAuthenticatedTestApp({ scope: '_test_scope' }, containersPermissions);
+    // we enable the experimental APIs for this set of tests
+    unregisteredApp = await createUnregisteredTestApp({ enableExperimentalApis: true });
+  });
+
+  it('fetch content', async () => {
+    const content = `hello world, on ${Math.round(Math.random() * 100000)}`;
+    const domain = await createRandomDomain(content, '', '', app);
+    const url = `safe://${domain}`;
+    const data = await unregisteredApp.fetch(url);
+    return should(data).equal(url);
+  });
+
+  it('fetch private content', async () => {
+    const content = `hello private world, on ${Math.round(Math.random() * 100000)}`;
+    const domain = await createRandomPrivateServiceDomain(content, '/yumyum.html', '', app);
+    const url = `safe://${domain}/yumyum.html`;
+    const data = await unregisteredApp.fetch(url);
+    return should(data).equal(url);
+  });
+});

--- a/test/experimental_apis/fetch.js
+++ b/test/experimental_apis/fetch.js
@@ -14,6 +14,7 @@
 const should = require('should');
 const h = require('../helpers');
 const consts = require('../../src/consts');
+const errConst = require('../../src/error_const');
 
 const createAuthenticatedTestApp = h.createAuthenticatedTestApp;
 const createUnregisteredTestApp = h.createUnregisteredTestApp;
@@ -71,6 +72,15 @@ describe('Fetching native objects', () => {
     app = await createAuthenticatedTestApp({ scope: '_test_scope' }, containersPermissions);
     // we enable the experimental APIs for this set of tests
     unregisteredApp = await createUnregisteredTestApp({ enableExperimentalApis: true });
+  });
+
+  it('fail if experimental apis not enabled', async () => {
+    const safeApp = await createUnregisteredTestApp({ enableExperimentalApis: false });
+    try {
+      await safeApp.fetch();
+    } catch (err) {
+      return should(err.message).equal(errConst.EXPERIMENTAL_API_DISABLED.msg('fetch'));
+    }
   });
 
   it('fetch content', async () => {

--- a/test/experimental_apis/fetch.js
+++ b/test/experimental_apis/fetch.js
@@ -75,12 +75,14 @@ describe('Fetching native objects', () => {
   });
 
   it('fail if experimental apis not enabled', async () => {
+    let error;
     const safeApp = await createUnregisteredTestApp({ enableExperimentalApis: false });
     try {
       await safeApp.fetch();
     } catch (err) {
-      return should(err.message).equal(errConst.EXPERIMENTAL_API_DISABLED.msg('fetch'));
+      error = err;
     }
+    return should(error.message).equal(errConst.EXPERIMENTAL_API_DISABLED.msg('fetch'));
   });
 
   it('fetch content', async () => {

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -26,8 +26,7 @@ const authUris = {
 const appInfo = {
   id: 'net.maidsafe.test.javascript.id',
   name: 'NodeJS Test',
-  vendor: 'MaidSafe.net Ltd',
-  forceUseMock: true
+  vendor: 'MaidSafe.net Ltd'
 };
 
 const createTestApp = async (partialAppInfo, networkCB, options, preventInit) => {
@@ -45,8 +44,8 @@ const createAuthenticatedTestApp = async (partialAppInfo, access, opts) => {
   return app.auth.loginForTest(access || {}, opts);
 };
 
-const createUnregisteredTestApp = async (scope) => {
-  const app = await createTestApp(scope);
+const createUnregisteredTestApp = async (opts) => {
+  const app = await createTestApp(null, null, opts);
   return app.auth.loginForTest();
 };
 


### PR DESCRIPTION
Resolves #284 