### PR TITLE
feat/experimental: add the 'fetch' experimental API

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -4,10 +4,12 @@
 ### Added
 - Add instructions to the README for how to generate API docs locally
 - Support for exposing experimental APIs when `--enable-experimental-apis` argument is passed, or when `enableExperimentalApis` flag is set in the initialisation option
+- Experimental function `fetch` which can fetch a network resource from a URL, returning the target network object (`content`), the type of the resource fetched (`resourceType`), and the parsed path from the provided URL (`parsedPath`)
 
 ### Changed
 - Dependency downloader configuration to download both mock and prod libs without `NODE_ENV=dev`
 - Upgrades deps_downloader to v0.3.0
+- Code refactoring in the browsing tests cases
 
 ### Fixed
 - Change docs to reflect testing condition for `loginForTest` and `simulateNetworkDisconnect` functions.

--- a/etc/documentation.yml
+++ b/etc/documentation.yml
@@ -28,6 +28,7 @@ toc:
 
   - name: Emulations
     description: Emulations and Abstractions on top of MData
+  - Emulation
   - NFS
   - File
 
@@ -43,6 +44,8 @@ toc:
   - CipherOpt
   - NameAndTag
   - ValueVersion
+  - NetworkResource
+  - WebFetchOptions
 
   - name: Errors
   - ERR_NO_SUCH_DATA

--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -278,22 +278,8 @@ class AuthInterface {
   * @return {Promise<MutableData>}
   */
   getOwnContainer() {
-    let prms = this.app.getOwnContainerName()
+    return this.app.getOwnContainerName()
       .then((containerName) => this.getContainer(containerName));
-
-    if (useMockByDefault || this.app.options.forceUseMock) {
-      prms = prms.catch((err) => {
-        // Error code -1002 corresponds to 'Container not found' case
-        if (err.code !== -1002) return Promise.reject(err);
-        return this.getContainersPermissions().then((contPerms) => {
-          const names = Object.keys(contPerms);
-          const ctrnName = names.find((x) => x.match(/^apps\//));
-          if (!ctrnName) return Promise.reject(err);
-          return this.getContainer(ctrnName);
-        });
-      });
-    }
-    return prms;
   }
 
   /**
@@ -387,7 +373,7 @@ class AuthInterface {
     }
     if (access) {
       const appInfo = makeAppInfo(this.app.appInfo);
-      const perms = makePermissions(access || {});
+      const perms = makePermissions(access);
       const authReq = new types.AuthReq({
         app: appInfo,
         app_container: !!(opts && opts.own_container),

--- a/src/app.js
+++ b/src/app.js
@@ -21,6 +21,7 @@ const makeError = require('./native/_error.js');
 const { webFetch, fetch } = require('./web_fetch.js');
 
 /**
+* @private
 * Validates appInfo and properly handles error
 */
 const validateAppInfo = (_appInfo) => {
@@ -41,6 +42,7 @@ const validateAppInfo = (_appInfo) => {
 };
 
 /**
+* @private
 * Init logging on the underlying library only if it wasn't done already
 */
 const initLogging = (appInfo, options) => {
@@ -57,6 +59,7 @@ const initLogging = (appInfo, options) => {
 };
 
 /**
+* @private
 * Set additional search path for the config files if it was requested in
 * the options. E.g. log.toml and crust.config files will be search
 * in this additional search path.
@@ -164,10 +167,25 @@ class SAFEApp extends EventEmitter {
     return this._mutableData;
   }
 
+  /**
+  * Function to lookup a given `safe://`-URL in accordance with the
+  * public name resolution and find the requested network resource.
+  *
+  * @param {String} url the url you want to fetch
+  * @param {WebFetchOptions} [options=null] additional options
+  * @returns {Promise<Object>} the object with body of content and headers
+  */
   webFetch(url, options) {
     return webFetch.call(this, url, options);
   }
 
+  /**
+  * Experipental function to lookup a given `safe://`-URL in accordance with the
+  * public name resolution and find the requested network resource.
+  *
+  * @param {String} url the url you want to fetch
+  * @returns {Promise<NetworkResource>} the network resource found from the passed URL
+  */
   fetch(url) {
     return fetch.call(this, url);
   }

--- a/src/error_const.js
+++ b/src/error_const.js
@@ -352,4 +352,28 @@ module.exports = {
     Pass --enable-experimental-apis argument to the application, or programatically
     set the 'enableExperimentalApis' flag in the initialisation options to enable them.`
   },
+
+  /**
+   * @name @ERR_SERVICE_NOT_FOUND
+   * @type {Object}
+   * @description the service/subname was not found
+   * @property {number} code 1022
+   * @property {function} msg
+   */
+  ERR_SERVICE_NOT_FOUND: {
+    code: 1022,
+    msg: 'Requested service is not found.'
+  },
+
+  /**
+   * @name @ERR_CONTENT_NOT_FOUND
+   * @type {Object}
+   * @description the content was not found at the address provided
+   * @property {number} code 1023
+   * @property {function} msg
+   */
+  ERR_CONTENT_NOT_FOUND: {
+    code: 1023,
+    msg: 'No content found at requested address.'
+  },
 };

--- a/src/web_fetch.js
+++ b/src/web_fetch.js
@@ -172,6 +172,12 @@ const readContentFromFile = async (openedFile, defaultMimeType, opts) => {
   return response;
 };
 
+// Helper function which is able to fetch a resource from the network
+// using a URL. It parses the URL and calls the subName/publicName resolver helper
+// (it can also call other type of resolvers like XOR-URL resolver in the future),
+// returning the network object that it's found with the applied URL resolution,
+// along with the type of the resolved network object and the path that was
+// parsed out from the URL.
 async function fetchHelper(url) {
   if (!url) return Promise.reject(makeError(errConst.MISSING_URL.code, errConst.MISSING_URL.msg));
 

--- a/src/web_fetch.js
+++ b/src/web_fetch.js
@@ -6,30 +6,37 @@ const mime = require('mime');
 const nodePath = require('path');
 const { EXPOSE_AS_EXPERIMENTAL_API } = require('./helpers');
 
-// Helper function to read fetch the Container
+const MIME_TYPE_BYTERANGES = 'multipart/byteranges';
+const MIME_TYPE_OCTET_STREAM = 'application/octet-stream';
+const HEADERS_CONTENT_TYPE = 'Content-Type';
+const HEADERS_CONTENT_LENGTH = 'Content-Length';
+const HEADERS_CONTENT_RANGE = 'Content-Range';
+const DATA_TYPE_NFS = 'NFS';
+
+// Helper function to fetch the Container
 // from a public ID and service name provided
-async function getContainerFromPublicId(pubName, servName) {
+async function getContainerFromPublicId(pubName, subName) {
   let serviceInfo;
   try {
     const address = await this.crypto.sha3Hash(pubName);
     const servicesContainer = await this.mutableData.newPublic(address, consts.TAG_TYPE_DNS);
-    serviceInfo = await servicesContainer.get(servName || 'www'); // default it to www
+    serviceInfo = await servicesContainer.get(subName || 'www'); // default it to www
   } catch (err) {
-    if (err.code === errConst.ERR_NO_SUCH_DATA.code ||
-        err.code === errConst.ERR_NO_SUCH_ENTRY.code) {
-      const error = {};
-      error.code = err.code;
-      error.message = `Requested ${err.code === errConst.ERR_NO_SUCH_DATA.code ? 'public name' : 'service'} is not found`;
-      throw makeError(error.code, error.message);
+    switch (err.code) {
+      case errConst.ERR_NO_SUCH_DATA.code:
+        // there is no container stored at the location
+        throw makeError(errConst.ERR_CONTENT_NOT_FOUND.code, errConst.ERR_CONTENT_NOT_FOUND.msg);
+      case errConst.ERR_NO_SUCH_ENTRY.code:
+        // there is no matching service name
+        throw makeError(errConst.ERR_SERVICE_NOT_FOUND.code, errConst.ERR_SERVICE_NOT_FOUND.msg);
+      default:
+        throw err;
     }
-    throw err;
   }
 
   if (serviceInfo.buf.length === 0) {
-    const error = {};
-    error.code = errConst.ERR_NO_SUCH_ENTRY.code;
-    error.message = `Service not found. ${errConst.ERR_NO_SUCH_ENTRY.msg}`;
-    throw makeError(error.code, error.message);
+    // the matching service name was soft-deleted
+    throw makeError(errConst.ERR_SERVICE_NOT_FOUND.code, errConst.ERR_SERVICE_NOT_FOUND.msg);
   }
 
   let serviceMd;
@@ -39,13 +46,14 @@ async function getContainerFromPublicId(pubName, servName) {
     serviceMd = await this.mutableData.newPublic(serviceInfo.buf, consts.TAG_TYPE_WWW);
   }
 
-  return serviceMd;
+  return { serviceMd, type: DATA_TYPE_NFS };
 }
 
 // Helper function to try different paths to find and
 // fetch the index file from a web site container
 const tryDifferentPaths = async (fetchFn, initialPath) => {
   const handleNfsFetchException = (error) => {
+    // only if it's an unexpected error throw it
     if (error.code !== errConst.ERR_FILE_NOT_FOUND.code) {
       throw error;
     }
@@ -76,8 +84,15 @@ const tryDifferentPaths = async (fetchFn, initialPath) => {
     }
   }
   if (!file) {
-    filePath = `${initialPath}/${consts.INDEX_HTML}`.replace('/', '');
-    file = await fetchFn(filePath);
+    try {
+      filePath = `${initialPath}/${consts.INDEX_HTML}`.replace('/', '');
+      file = await fetchFn(filePath);
+    } catch (error) {
+      if (error.code !== errConst.ERR_FILE_NOT_FOUND.code) {
+        throw error;
+      }
+      throw makeError(error.code, errConst.ERR_FILE_NOT_FOUND.msg);
+    }
   }
 
   const mimeType = mime.getType(nodePath.extname(filePath));
@@ -89,7 +104,7 @@ const tryDifferentPaths = async (fetchFn, initialPath) => {
 const readContentFromFile = async (openedFile, defaultMimeType, opts) => {
   let mimeType = defaultMimeType;
   if (!mimeType) {
-    mimeType = 'application/octet-stream';
+    mimeType = MIME_TYPE_OCTET_STREAM;
   }
   let range;
   let start = consts.pubConsts.NFS_FILE_START;
@@ -124,8 +139,8 @@ const readContentFromFile = async (openedFile, defaultMimeType, opts) => {
       return {
         body: byteSegment,
         headers: {
-          'Content-Type': mimeType,
-          'Content-Range': `bytes ${partStart}-${partEnd}/${fileSize}`
+          [HEADERS_CONTENT_TYPE]: mimeType,
+          [HEADERS_CONTENT_RANGE]: `bytes ${partStart}-${partEnd}/${fileSize}`
         }
       };
     }));
@@ -135,40 +150,70 @@ const readContentFromFile = async (openedFile, defaultMimeType, opts) => {
   }
 
   if (multipart) {
-    mimeType = 'multipart/byteranges';
+    mimeType = MIME_TYPE_BYTERANGES;
   }
 
   const response = {
     headers: {
-      'Content-Type': mimeType
+      [HEADERS_CONTENT_TYPE]: mimeType
     },
     body: data
   };
 
   if (range && multipart) {
-    response.headers['Content-Length'] = JSON.stringify(data).length;
+    response.headers[HEADERS_CONTENT_LENGTH] = JSON.stringify(data).length;
     delete response.body;
     response.parts = data;
   } else if (range) {
     endByte = (end === fileSize - 1) ? fileSize - 1 : end;
-    response.headers['Content-Length'] = lengthToRead;
-    response.headers['Content-Range'] = `bytes ${start}-${endByte}/${fileSize}`;
+    response.headers[HEADERS_CONTENT_LENGTH] = lengthToRead;
+    response.headers[HEADERS_CONTENT_RANGE] = `bytes ${start}-${endByte}/${fileSize}`;
   }
   return response;
 };
 
+async function fetchHelper(url) {
+  if (!url) return Promise.reject(makeError(errConst.MISSING_URL.code, errConst.MISSING_URL.msg));
+
+  const parsedUrl = parseUrl(url);
+
+  if (!parsedUrl.protocol) return Promise.reject(makeError(errConst.INVALID_URL.code, `${errConst.INVALID_URL.msg}, complete with protocol.`));
+
+  const hostParts = parsedUrl.hostname.split('.');
+  const publicName = hostParts.pop(); // last one is 'publicName'
+  const subName = hostParts.join('.'); // all others are the 'subName'
+  const parsedPath = parsedUrl.pathname ? decodeURI(parsedUrl.pathname) : '';
+
+  // Let's try to find the container and read
+  // its content using the helpers functions
+  const md = await getContainerFromPublicId.call(this, publicName, subName);
+  return {
+    content: md.serviceMd,
+    resourceType: md.type,
+    parsedPath
+  };
+}
+
 /**
-* Helper to lookup a given `safe://`-url in accordance with the
-* convention and find the requested object.
+* @typedef {Object} NetworkResource
+* holds information about a network resource fetched from a `safe://`-URL
+* @param {Object} content the network resource object
+* @param {Object} resourceType the type of the resource fetched, e.g. 'NFS'
+* @param {Object} parsedPath the parsed path from the provided URL
+*/
+
+/**
+* @private
+* Helper experipental function to lookup a given `safe://`-URL in accordance with the
+* public name resolution and find the requested network resource.
 *
 * @param {String} url the url you want to fetch
-* @returns {Promise<Object>} the native object
+* @returns {Promise<NetworkResource>} the network resource found from the passed URL
 */
 async function fetch(url) {
   /* eslint-disable no-shadow, prefer-arrow-callback */
   return EXPOSE_AS_EXPERIMENTAL_API.call(this, async function fetch() {
-    // implementation of fetch function goes here
-    return url;
+    return fetchHelper.call(this, url);
   });
 }
 
@@ -187,47 +232,28 @@ async function fetch(url) {
 */
 
 /**
-* Helper to lookup a given `safe://`-url in accordance with the
-* convention and find the requested object.
+* @private
+* Helper function to lookup a given `safe://`-URL in accordance with the
+* public name resolution and find the requested network resource.
 *
 * @param {String} url the url you want to fetch
 * @param {WebFetchOptions} [options=null] additional options
 * @returns {Promise<Object>} the object with body of content and headers
 */
 async function webFetch(url, options) {
-  if (!url) return Promise.reject(makeError(errConst.MISSING_URL.code, errConst.MISSING_URL.msg));
+  const { content, resourceType, parsedPath } = await fetchHelper.call(this, url);
 
-  const parsedUrl = parseUrl(url);
-  const hostname = parsedUrl.hostname;
-  let path = parsedUrl.pathname ? decodeURI(parsedUrl.pathname) : '';
-  const tokens = path.split('/');
+  const emulation = await content.emulateAs(resourceType);
+  const tokens = parsedPath.split('/');
   if (!tokens[tokens.length - 1] && tokens.length > 1) {
     tokens.pop();
     tokens.push(consts.INDEX_HTML);
   }
-
-  path = tokens.join('/') || `/${consts.INDEX_HTML}`;
-
-  // lets' unpack
-  const hostParts = hostname.split('.');
-  const lookupName = hostParts.pop(); // last one is 'domain'
-  const serviceName = hostParts.join('.'); // all others are 'service'
-
-  return new Promise(async (resolve, reject) => {
-    const boundGetContainerFromPublicId = getContainerFromPublicId.bind(this);
-    try {
-      // Let's try to find the container and read
-      // its content using the helpers functions
-      const serviceMd = await boundGetContainerFromPublicId(lookupName, serviceName);
-      const emulation = await serviceMd.emulateAs('NFS');
-      const { file, mimeType } = await tryDifferentPaths(emulation.fetch.bind(emulation), path);
-      const openedFile = await emulation.open(file, consts.pubConsts.NFS_FILE_MODE_READ);
-      const data = await readContentFromFile(openedFile, mimeType, options);
-      resolve(data);
-    } catch (e) {
-      reject(e);
-    }
-  });
+  const path = tokens.join('/') || `/${consts.INDEX_HTML}`;
+  const { file, mimeType } = await tryDifferentPaths(emulation.fetch.bind(emulation), path);
+  const openedFile = await emulation.open(file, consts.pubConsts.NFS_FILE_MODE_READ);
+  const data = await readContentFromFile(openedFile, mimeType, options);
+  return data;
 }
 
 module.exports = {

--- a/test/browsing.js
+++ b/test/browsing.js
@@ -433,6 +433,9 @@ describe('Browsing', () => {
         domain = testDomain;
       }).then(() => { client = unregisteredApp; }));
 
+    it('no protocol in url', () => should(client.webFetch('domain_doesnt_exist'))
+      .be.rejectedWith(`${errConst.INVALID_URL.msg}, complete with protocol.`));
+
     it('should throw error when a previously existing service is removed', async () => {
       const deletedService = 'nonexistant';
       const { domain: testDomain } = await createRandomDomain(content, '', deletedService, app);

--- a/test/experimental_apis/fetch.js
+++ b/test/experimental_apis/fetch.js
@@ -12,56 +12,12 @@
 
 
 const should = require('should');
-const h = require('../helpers');
-const consts = require('../../src/consts');
+const helpers = require('../helpers');
 const errConst = require('../../src/error_const');
 
-const createAuthenticatedTestApp = h.createAuthenticatedTestApp;
-const createUnregisteredTestApp = h.createUnregisteredTestApp;
-
-const createRandomDomain = async (content, path, service, authedApp) => {
-  const domain = `test_${Math.round(Math.random() * 100000)}`;
-  const app = authedApp || await createAuthenticatedTestApp();
-  return app.mutableData.newRandomPublic(consts.TAG_TYPE_WWW)
-    .then((serviceMdata) => serviceMdata.quickSetup()
-      .then(() => {
-        const nfs = serviceMdata.emulateAs('NFS');
-        // let's write the file
-        return nfs.create(content)
-          .then((file) => nfs.insert(path || '/index.html', file))
-          .then(() => app.crypto.sha3Hash(domain)
-            .then((dnsName) => app.mutableData.newPublic(dnsName, consts.TAG_TYPE_DNS)
-              .then((dnsData) => serviceMdata.getNameAndTag()
-                  .then((res) => {
-                    const payload = {};
-                    payload[service || 'www'] = res.name;
-                    return dnsData.quickSetup(payload);
-                  }))));
-      }))
-    .then(() => domain);
-};
-
-const createRandomPrivateServiceDomain = async (content, path, service, authedApp) => {
-  const domain = `test_${Math.round(Math.random() * 100000)}`;
-  const app = authedApp || await createAuthenticatedTestApp();
-  return app.mutableData.newRandomPrivate(consts.TAG_TYPE_WWW)
-    .then((serviceMdata) => serviceMdata.quickSetup()
-      .then(() => {
-        const nfs = serviceMdata.emulateAs('NFS');
-        // let's write the file
-        return nfs.create(content)
-          .then((file) => nfs.insert(path || '', file))
-          .then(() => app.crypto.sha3Hash(domain)
-            .then((dnsName) => app.mutableData.newPublic(dnsName, consts.TAG_TYPE_DNS))
-              .then((dnsData) => serviceMdata.serialise()
-                  .then((serial) => {
-                    const payload = {};
-                    payload[service || ''] = serial;
-                    return dnsData.quickSetup(payload);
-                  })));
-      }))
-    .then(() => domain);
-};
+const createAuthenticatedTestApp = helpers.createAuthenticatedTestApp;
+const createUnregisteredTestApp = helpers.createUnregisteredTestApp;
+const createRandomDomain = helpers.createRandomDomain;
 
 const containersPermissions = { _public: ['Read'], _publicNames: ['Read', 'Insert', 'ManagePermissions'] };
 
@@ -69,7 +25,9 @@ describe('Fetching native objects', () => {
   let app;
   let unregisteredApp;
   before(async () => {
-    app = await createAuthenticatedTestApp({ scope: '_test_scope' }, containersPermissions);
+    app = await createAuthenticatedTestApp({ scope: '_test_scope' },
+                                            containersPermissions, null,
+                                            { enableExperimentalApis: true });
     // we enable the experimental APIs for this set of tests
     unregisteredApp = await createUnregisteredTestApp({ enableExperimentalApis: true });
   });
@@ -85,19 +43,22 @@ describe('Fetching native objects', () => {
     return should(error.message).equal(errConst.EXPERIMENTAL_API_DISABLED.msg('fetch'));
   });
 
-  it('fetch content', async () => {
+  it('fetch an NFS resource', async () => {
     const content = `hello world, on ${Math.round(Math.random() * 100000)}`;
-    const domain = await createRandomDomain(content, '', '', app);
-    const url = `safe://${domain}`;
-    const data = await unregisteredApp.fetch(url);
-    return should(data).equal(url);
+    const filePath = '/yumyum.html';
+    const { domain } = await createRandomDomain(content, filePath, '', app);
+    const url = `safe://${domain}${filePath}#me`;
+    const networkResource = await unregisteredApp.fetch(url);
+    should(networkResource.resourceType).equal('NFS');
+    should(networkResource.parsedPath).equal(filePath);
+    return should(networkResource.content.get(filePath)).be.fulfilled();
   });
 
-  it('fetch private content', async () => {
-    const content = `hello private world, on ${Math.round(Math.random() * 100000)}`;
-    const domain = await createRandomPrivateServiceDomain(content, '/yumyum.html', '', app);
-    const url = `safe://${domain}/yumyum.html`;
-    const data = await unregisteredApp.fetch(url);
-    return should(data).equal(url);
+  // not supported yet, it needs support for XOR-URL
+  it.skip('fetch a MD resource', async () => {
+  });
+
+  // not supported yet, it needs support for XOR-URL
+  it.skip('fetch an IMD resource', async () => {
   });
 });


### PR DESCRIPTION
The `fetch` experimental API allows apps to fetch a network resource from a URL, specially needed by apps supporting linked data.
This function is enabled with the `--enable-experimental-apis` and it returns an object with:
- the target network resource (`content`)
- the type of the resource fetched (`resourceType`)
- and the parsed path from the provided URL (`parsedPath`)

Resolves #290 