### PR TITLE
feat/xor-urls: expose experimental APIs and resolver functionality for XOR-URLs

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -4,12 +4,7 @@
 ### Added
 - Add instructions to the README for how to generate API docs locally
 - Support for exposing experimental APIs when `--enable-experimental-apis` argument is passed, or when `enableExperimentalApis` flag is set in the initialisation option
-- Experimental function `fetch` which can fetch a network resource from a URL, returning the target network object (`content`), the type of the resource fetched (`resourceType`), and the parsed path from the provided URL (`parsedPath`)
-- Experimental RDF emulation layer which provides an abstraction to generate and manipulate RDF data on the SAFE network
-- Experimental WebID emulation layer which provides an abstraction to generate and manipulate WebID profile documents on the SAFE network.
-- Experimental Web API which provides utilities to manage public names and subNames, get the list of owned WebIDs, get list of owned public names, etc.
-- Rename `isMockBuild` function to `appIsMock` to match the renaming in safe_app lib v0.9.0.
-- Constant to automatically obtain correct file version for updates and deletes
+- Constant `GET_NEXT_VERSION` added to automatically obtain correct file version for updates and deletes
 
 ### Changed
 - Dependency downloader configuration to download both mock and prod libs without `NODE_ENV=dev`
@@ -17,6 +12,7 @@
 - Code refactoring in the browsing tests cases
 - Upgrade safe_app native library to v0.9.0
 - Refactors instances of deprecated `new Buffer` to `Buffer.from` to comply with Node v10
+- Rename `isMockBuild` function to `appIsMock` to match the renaming in safe_app lib v0.9.0
 
 ### Fixed
 - Change docs to reflect testing condition for `loginForTest` and `simulateNetworkDisconnect` functions.
@@ -24,6 +20,16 @@
 - RDF emulation now encrypts also the entries' values (issue #281)
 - RDF emulation now can decrypt data fetched from a private MutableData (issue #283)
 - Resolved issue #282, populate `_publicNames` correctly when creating multiple WebIDs
+
+### Experimental APIs/features (enabled with `--enable-experimental-apis`)
+- Experimental function `fetch` which can fetch a network resource from a URL, returning the target network object (`content`), the type of the resource fetched (`resourceType`), and the parsed path from the provided URL (`parsedPath`)
+- Experimental RDF emulation layer which provides an abstraction to generate and manipulate RDF data on the SAFE network
+- Experimental WebID emulation layer which provides an abstraction to generate and manipulate WebID profile documents on the SAFE network
+- Experimental Web API which provides utilities to manage publicNames and subNames, get the list of owned WebIDs, get the list of owned Public Names, etc.
+- The `webFetch` function supports XOR-URLs as an experimental feature
+- The MutableData `getNameAndTag` function returns the XOR-URL as `xorUrl` attribute in the returned object
+- The ImmutableData `close` function of the `Writer` accepts an additional `getXorUrl` boolean argument to request the XOR-URL which is returned along with the XOR name in an object: `{ name: <xor addr>, xorUrl: <XOR-URL> }`
+- The ImmutableData `close` function of the `Writer` accepts the `mimeType` additional argument to be used as the content-type encoded in the XOR-URL being generated
 
 ### SAFE libraries Dependencies
 - safe_app: v0.9.0

--- a/package.json
+++ b/package.json
@@ -39,11 +39,13 @@
     "src/native/*.js"
   ],
   "dependencies": {
+    "cids": "bochaco/js-cid#temp-use-bochaco-multicodec",
     "cross-env": "5.1.3",
     "deps_downloader": "https://s3.eu-west-2.amazonaws.com/deps-downloader/deps_downloader-0.3.0.tgz",
     "enum": "^2.3.0",
     "ffi": "^2.2.0",
     "mime": "^2.0.3",
+    "multihashes": "^0.4.14",
     "rdflib": "^0.19.0",
     "ref": "^1.3.3",
     "ref-array": "^1.2.0",

--- a/src/api/emulations/rdf.js
+++ b/src/api/emulations/rdf.js
@@ -14,7 +14,7 @@
 const rdflib = require('rdflib');
 const errConst = require('../../error_const');
 const makeError = require('../../native/_error.js');
-const { EXPOSE_AS_EXPERIMENTAL_API_SYNC } = require('../../helpers');
+const { EXPOSE_AS_EXPERIMENTAL_API } = require('../../helpers');
 
 const JSON_LD_MIME_TYPE = 'application/ld+json';
 const RDF_GRAPH_ID = '@id';
@@ -314,7 +314,7 @@ class rdfEmulationFactory {
   */
   constructor(mData) {
     /* eslint-disable camelcase, prefer-arrow-callback */
-    return EXPOSE_AS_EXPERIMENTAL_API_SYNC.call(mData.app, function RDF_Emulation() {
+    return EXPOSE_AS_EXPERIMENTAL_API.call(mData.app, function RDF_Emulation() {
       return new RDF(mData);
     });
   }

--- a/src/api/emulations/web_id.js
+++ b/src/api/emulations/web_id.js
@@ -12,7 +12,7 @@
 
 const consts = require('../../consts');
 const { parse: parseUrl } = require('url');
-const { EXPOSE_AS_EXPERIMENTAL_API_SYNC } = require('../../helpers');
+const { EXPOSE_AS_EXPERIMENTAL_API } = require('../../helpers');
 
 // Helper for creating a WebID profile document RDF resource
 const createWebIdProfileDoc = async (rdf, vocabs, profile, postsLocation) => {
@@ -144,7 +144,7 @@ class WebIdEmulationFactory {
   */
   constructor(mData) {
     /* eslint-disable camelcase, prefer-arrow-callback */
-    return EXPOSE_AS_EXPERIMENTAL_API_SYNC.call(mData.app, function WebID_Emulation() {
+    return EXPOSE_AS_EXPERIMENTAL_API.call(mData.app, function WebID_Emulation() {
       return new WebID(mData);
     });
   }

--- a/src/app.js
+++ b/src/app.js
@@ -19,7 +19,7 @@ const consts = require('./consts');
 const errConst = require('./error_const');
 const makeError = require('./native/_error.js');
 const { webFetch, fetch } = require('./web_fetch.js');
-const { EXPOSE_AS_EXPERIMENTAL_API_SYNC } = require('./helpers');
+const { EXPOSE_AS_EXPERIMENTAL_API } = require('./helpers');
 
 /**
 * @private
@@ -142,7 +142,7 @@ class SAFEApp extends EventEmitter {
    */
   get web() {
     /* eslint-disable camelcase, prefer-arrow-callback */
-    return EXPOSE_AS_EXPERIMENTAL_API_SYNC.call(this, function Web_API() {
+    return EXPOSE_AS_EXPERIMENTAL_API.call(this, function Web_API() {
       return this._web;
     });
   }

--- a/src/consts.js
+++ b/src/consts.js
@@ -111,6 +111,12 @@ const SYSTEM_URI_LIB_FILENAME = {
 
 const INDEX_HTML = 'index.html';
 
+const CID_VERSION = 1;
+const CID_BASE_ENCODING = 'base32z';
+const CID_HASH_FN = 'sha3-256';
+const CID_DEFAULT_CODEC = 'raw';
+const CID_MIME_CODEC_PREFIX = 'mime/';
+
 module.exports = {
   TAG_TYPE_DNS,
   TAG_TYPE_WWW,
@@ -126,5 +132,11 @@ module.exports = {
   pubConsts,
 
   SAFE_APP_LIB_FILENAME,
-  SYSTEM_URI_LIB_FILENAME
+  SYSTEM_URI_LIB_FILENAME,
+
+  CID_VERSION,
+  CID_BASE_ENCODING,
+  CID_HASH_FN,
+  CID_DEFAULT_CODEC,
+  CID_MIME_CODEC_PREFIX,
 };

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -209,6 +209,15 @@ const getSafeAppLibFilename = (defaultDir, options) =>
 const getSystemUriLibFilename = (defaultDir, options) =>
   getNativeLibPath(defaultDir, options, consts.SYSTEM_URI_LIB_FILENAME);
 
+const escapeHtmlEntities = (str) =>
+    str
+      .replace(/&/g, '&amp;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/\//g, '&#x2F;');
+
 module.exports = {
   EXPOSE_AS_EXPERIMENTAL_API,
   ONLY_IF_EXPERIMENTAL_API_ENABLED,
@@ -217,5 +226,6 @@ module.exports = {
   autoref,
   validateShareMDataPermissions,
   getSafeAppLibFilename,
-  getSystemUriLibFilename
+  getSystemUriLibFilename,
+  escapeHtmlEntities
 };

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -64,8 +64,8 @@ function checkExperimentalApisFlag(fn) {
   this._warningLoggedAlready = true;
 }
 
-/* Helper to be used by all __ASYNC__ experimental APIs.
- * For example, the following snippet shows how an experimental (async) function
+/* Helper to be used by all experimental APIs (async and sync).
+ * For example, the following snippet shows how an experimental function
  * called 'testFn' can be exposed:
  * async function testFn(arg1, arg2) {
      return EXPOSE_AS_EXPERIMENTAL_API.call(this, async function testFn() {
@@ -75,26 +75,20 @@ function checkExperimentalApisFlag(fn) {
      });
  * }
 */
-async function EXPOSE_AS_EXPERIMENTAL_API(fn) {
-  checkExperimentalApisFlag.call(this, fn);
-  const res = await fn.call(this);
-  return res;
-}
-
-/* Helper to be used by all __SYNC__ experimental APIs (only for sync APIs).
- * For example, the following snippet shows how an experimental (sync) function
- * called 'testSyncFn' can be exposed:
- * async function testSyncFn(arg1, arg2) {
-     return EXPOSE_AS_EXPERIMENTAL_API_SYNC.call(this, function testSyncFn() {
-       // 'testSyncFn' function's actual implementation goes here
-       console.log("Experimental Sync Function which uses arg1 and arg2: ", arg1, arg2);
-       ...
-     });
- * }
-*/
-function EXPOSE_AS_EXPERIMENTAL_API_SYNC(fn) {
+function EXPOSE_AS_EXPERIMENTAL_API(fn) {
   checkExperimentalApisFlag.call(this, fn);
   return fn.call(this);
+}
+
+/* Helper to be used by experimental features which shouldn't
+ * be executed if the enableExperimentalApis flag is not set.
+ * Note this doesn't trigger any exeception or warning message if the flag is
+ * not set, it's just helps to execute/skip a piece of experimental funcitonality.
+*/
+function ONLY_IF_EXPERIMENTAL_API_ENABLED(fn) {
+  if (isExperimentalApisEnabled || this.options.enableExperimentalApis) {
+    return fn.call(this);
+  }
 }
 
 /**
@@ -217,7 +211,7 @@ const getSystemUriLibFilename = (defaultDir, options) =>
 
 module.exports = {
   EXPOSE_AS_EXPERIMENTAL_API,
-  EXPOSE_AS_EXPERIMENTAL_API_SYNC,
+  ONLY_IF_EXPERIMENTAL_API_ENABLED,
   useMockByDefault,
   NetworkObject,
   autoref,

--- a/src/web_fetch.js
+++ b/src/web_fetch.js
@@ -7,7 +7,7 @@ const nodePath = require('path');
 const multihash = require('multihashes');
 const CID = require('cids');
 const { EXPOSE_AS_EXPERIMENTAL_API,
-        ONLY_IF_EXPERIMENTAL_API_ENABLED } = require('./helpers');
+        ONLY_IF_EXPERIMENTAL_API_ENABLED, escapeHtmlEntities } = require('./helpers');
 
 const MIME_TYPE_BYTERANGES = 'multipart/byteranges';
 const MIME_TYPE_OCTET_STREAM = 'application/octet-stream';
@@ -304,12 +304,11 @@ async function genMDExplorerHtml(url, md) {
    // TODO: confirm this will be ok for any type of data stored in MD entries,
   // e.g. binary data or different charset encodings, etc.
   entriesList.forEach((entry) => {
-    const key = entry.key.toString();
+    const key = escapeHtmlEntities(entry.key.toString());
     const version = entry.value.version;
     let value;
     if (entry.value.buf.length > 0) {
-      value = entry.value.buf.toString();
-      value = value.replace(/safe:\/\/[^\s^"]*/gi, (str) => (`<a href='${str}'>${str}</a>`));
+      value = escapeHtmlEntities(entry.value.buf.toString());
     } else {
       value = '<i>-- entry deleted --</i>';
     }

--- a/src/web_fetch.js
+++ b/src/web_fetch.js
@@ -4,13 +4,19 @@ const makeError = require('./native/_error.js');
 const { parse: parseUrl } = require('url');
 const mime = require('mime');
 const nodePath = require('path');
-const { EXPOSE_AS_EXPERIMENTAL_API } = require('./helpers');
+const multihash = require('multihashes');
+const CID = require('cids');
+const { EXPOSE_AS_EXPERIMENTAL_API,
+        ONLY_IF_EXPERIMENTAL_API_ENABLED } = require('./helpers');
 
 const MIME_TYPE_BYTERANGES = 'multipart/byteranges';
 const MIME_TYPE_OCTET_STREAM = 'application/octet-stream';
+const MIME_TYPE_HTML = 'text/html';
 const HEADERS_CONTENT_TYPE = 'Content-Type';
 const HEADERS_CONTENT_LENGTH = 'Content-Length';
 const HEADERS_CONTENT_RANGE = 'Content-Range';
+const DATA_TYPE_MD = 'MD';
+const DATA_TYPE_IMMD = 'IMMD';
 const DATA_TYPE_NFS = 'NFS';
 const DATA_TYPE_RDF = 'RDF';
 
@@ -196,6 +202,41 @@ const readContentFromFile = async (openedFile, defaultMimeType, opts) => {
   return response;
 };
 
+// Helper function to fetch the Container/content from a CID
+async function getContainerFromCid(cidString, typeTag) {
+  let content;
+  let type;
+  let codec;
+  try {
+    const cid = new CID(cidString);
+    const encodedHash = multihash.decode(cid.multihash);
+    const address = encodedHash.digest;
+    codec = cid.codec.replace(consts.CID_MIME_CODEC_PREFIX, '');
+    if (codec === consts.CID_DEFAULT_CODEC) {
+      codec = consts.MIME_TYPE_OCTET_STREAM;
+    }
+    if (typeTag) {
+      // it's supposed to be a MutableData
+      content = await this.mutableData.newPublic(address, typeTag);
+      await content.getEntries();
+      type = DATA_TYPE_MD;
+    } else {
+      // then it's supposed to be an ImmutableData
+      content = await this.immutableData.fetch(address);
+      type = DATA_TYPE_IMMD;
+    }
+  } catch (err) {
+    // only if it was looking up specifically for a MD thru a CID
+    // we report it as failing to find content
+    if (typeTag) {
+      throw makeError(errConst.ERR_CONTENT_NOT_FOUND.code, errConst.ERR_CONTENT_NOT_FOUND.msg);
+    }
+    // it's not a valid CID then
+    throw err;
+  }
+  return { content, type, codec };
+}
+
 // Helper function which is able to fetch a resource from the network
 // using a URL. It parses the URL and calls the subName/publicName resolver helper
 // (it can also call other type of resolvers like XOR-URL resolver in the future),
@@ -212,16 +253,149 @@ async function fetchHelper(url) {
   const hostParts = parsedUrl.hostname.split('.');
   const publicName = hostParts.pop(); // last one is 'publicName'
   const subName = hostParts.join('.'); // all others are the 'subName'
-  const parsedPath = parsedUrl.pathname ? decodeURI(parsedUrl.pathname) : '';
 
-  // Let's try to find the container and read
-  // its content using the helpers functions
+  // let's decompose and normalise the path
+  const originalPath = (parsedUrl.pathname === '/') ? '' : parsedUrl.pathname;
+  const parsedPath = originalPath ? decodeURI(originalPath) : '';
+
+  try {
+    const resource = await ONLY_IF_EXPERIMENTAL_API_ENABLED.call(this, async () => {
+      if (subName.length === 0) {
+        // this could be a XOR-URL, let's try to
+        // decode the publicName part as a CID
+        const content = await getContainerFromCid.call(this, publicName,
+                                                        parseInt(parsedUrl.port, 10));
+
+        const resourceType = (content.type === DATA_TYPE_MD) ? DATA_TYPE_NFS : content.type;
+
+        return {
+          content: content.content,
+          resourceType,
+          parsedPath,
+          mimeType: content.codec
+        };
+      }
+    });
+    if (resource) return resource;
+  } catch (err) {
+    if (err.code === errConst.ERR_CONTENT_NOT_FOUND.code) {
+      // it was meant to be found as a CID but content wasn't found,
+      // so let's throw the error
+      throw (err);
+    }
+    // then just fallback to public name lookup
+  }
+
+  // Let's then try to find the container by a public name lookup,
+  // and read its content using the helpers functions
   const md = await getContainerFromPublicId.call(this, publicName, subName);
   return {
     content: md.serviceMd,
     resourceType: md.type,
     parsedPath
   };
+}
+
+// helper function to generate an HTML based MutableData visualiser and explorer
+async function genMDExplorerHtml(url, md) {
+  const entries = await md.getEntries();
+  const entriesList = await entries.listEntries();
+  let tbody = '';
+   // TODO: confirm this will be ok for any type of data stored in MD entries,
+  // e.g. binary data or different charset encodings, etc.
+  entriesList.forEach((entry) => {
+    const key = entry.key.toString();
+    const version = entry.value.version;
+    let value;
+    if (entry.value.buf.length > 0) {
+      value = entry.value.buf.toString();
+      value = value.replace(/safe:\/\/[^\s^"]*/gi, (str) => (`<a href='${str}'>${str}</a>`));
+    } else {
+      value = '<i>-- entry deleted --</i>';
+    }
+    tbody += `
+      <tr>
+        <td class="detailsColumn">${key}</td>
+        <td class="detailsColumn">${version}</td>
+        <td class="detailsColumn">${value}</td>
+      </tr>`;
+  });
+  const perms = await md.getPermissions();
+  const permsSetList = await perms.listPermissionSets();
+  const getPermsInfo = permsSetList.map((perm) => perm.signKey.getRaw()
+      .then((raw) => ({ permSet: perm.permSet, signKey: raw.buffer.toString('hex') }))
+  );
+  const permsList = await Promise.all(getPermsInfo);
+  let tperms = '';
+   /* eslint-disable dot-notation */
+  permsList.forEach((perm) => {
+    tperms += `
+      <tr>
+        <td class="detailsColumn">
+          <input type="checkbox" disabled ${perm.permSet['Read'] ? 'checked' : ''}>Read
+          <input type="checkbox" disabled ${perm.permSet['Insert'] ? 'checked' : ''}>Insert<br/>
+          <input type="checkbox" disabled ${perm.permSet['Update'] ? 'checked' : ''}>Update
+          <input type="checkbox" disabled ${perm.permSet['Delete'] ? 'checked' : ''}>Delete<br/>
+          <input type="checkbox" disabled ${perm.permSet['ManagePermissions'] ? 'checked' : ''}>Manage Permissions
+        </td>
+        <td class="detailsColumn">0x${perm.signKey}</td>
+      </tr>`;
+  });
+  /* eslint-enable dot-notation */
+  const htmlPage = `
+    <html>
+      <head>
+        <title>MutableData at ${url}</title>
+        <style>
+          h2 {
+            border-bottom: 1px solid #c0c0c0;
+            margin-bottom: 10px;
+            padding-bottom: 10px;
+            white-space: nowrap;
+          }
+           tr:nth-child(odd) {
+              background-color: #dddddd;
+          }
+           td.detailsColumn {
+            -webkit-padding-start: 1em;
+            -webkit-padding-end: 1em;
+            white-space: nowrap;
+          }
+           td {
+            padding-right: 5px;
+          }
+        </style>
+      </head>
+      <body>
+        <h2>MutableData at ${url}</h2>
+        <h3>Entries:</h3>
+        <table>
+          <thead>
+            <tr>
+              <th>Key</th>
+              <th>Version</th>
+              <th>Value</th>
+            </tr>
+          </thead>
+          <tbody>
+            ${tbody}
+          </tbody>
+        </table>
+        <h3>Permissions:</h3>
+        <table>
+          <thead>
+            <tr>
+              <th>Permissions Set</th>
+              <th>Sign Key</th>
+            </tr>
+          </thead>
+          <tbody>
+            ${tperms}
+          </tbody>
+        </table>
+      </body>
+    </html>`;
+  return htmlPage;
 }
 
 /**
@@ -271,9 +445,9 @@ async function fetch(url) {
 * @returns {Promise<Object>} the object with body of content and headers
 */
 async function webFetch(url, options) {
-  const { content, resourceType, parsedPath } = await fetchHelper.call(this, url);
-  const emulation = content.emulateAs(resourceType);
+  const { content, resourceType, parsedPath, mimeType } = await fetchHelper.call(this, url);
   if (resourceType === DATA_TYPE_RDF) {
+    const emulation = content.emulateAs(resourceType);
     await emulation.nowOrWhenFetched();
 
     // TODO: support qvalue in the Accept header with multile mime types and weights
@@ -288,18 +462,50 @@ async function webFetch(url, options) {
       body: serialisedRdf
     };
     return response;
+  } else if (resourceType === DATA_TYPE_IMMD) {
+    const data = await readContentFromFile(content, mimeType, options);
+    return data;
   }
 
+  // then it's expected to be an NFS container
   const tokens = parsedPath.split('/');
   if (!tokens[tokens.length - 1] && tokens.length > 1) {
     tokens.pop();
     tokens.push(consts.INDEX_HTML);
   }
   const path = tokens.join('/') || `/${consts.INDEX_HTML}`;
-  const { file, mimeType } = await tryDifferentPaths(emulation.fetch.bind(emulation), path);
-  const openedFile = await emulation.open(file, consts.pubConsts.NFS_FILE_MODE_READ);
-  const data = await readContentFromFile(openedFile, mimeType, options);
-  return data;
+  try {
+    const emulation = content.emulateAs(resourceType);
+    const { file, mimeType: fileMimeType } = await
+                            tryDifferentPaths(emulation.fetch.bind(emulation), path);
+    const openedFile = await emulation.open(file, consts.pubConsts.NFS_FILE_MODE_READ);
+    const data = await readContentFromFile(openedFile, fileMimeType, options);
+    return data;
+  } catch (err) {
+    if (parsedPath) {
+      // it was meant to fetch a path so throw the error
+      throw (err);
+    }
+
+    // We couldn't read it with NFS emulation, and there was no path,
+    // if experimental apis are enabled let's generate a MD viewer
+    const mdViewer = await ONLY_IF_EXPERIMENTAL_API_ENABLED.call(this, async () => {
+      // we couldn't read it as an NFS Container, it's a simple MD,
+      // then let's return it as an html page to see the entries, follow links...
+      const body = await genMDExplorerHtml(url, content);
+      return {
+        headers: {
+          [HEADERS_CONTENT_TYPE]: MIME_TYPE_HTML
+        },
+        body
+      };
+    });
+
+    // ok, that's a shame, let's just return the error then
+    if (!mdViewer) throw err;
+
+    return mdViewer;
+  }
 }
 
 module.exports = {

--- a/test/experimental_apis/web.js
+++ b/test/experimental_apis/web.js
@@ -57,6 +57,13 @@ describe('Experimental Web API', () => {
       return should(error.message).match(/'_publicNames' not found in the access container/);
     });
 
+    it('should return empty array of getPublicNames when none set', async () => {
+      const authedApp = await h.publicNamesTestApp();
+      const webIds = await authedApp.web.getPublicNames();
+      should(webIds).be.a.Array();
+      should(webIds).have.length(0);
+    });
+
     it('should return the array of getPublicNames (a length greater than 0)', async () => {
       const authedApp = await h.publicNamesTestApp();
       const md = await authedApp.mutableData.newPublic(xorname, TYPE_TAG);
@@ -66,7 +73,7 @@ describe('Experimental Web API', () => {
 
       const webIds = await authedApp.web.getPublicNames();
       should(webIds).be.a.Array();
-      return should(webIds.length).be.greaterThan(0);
+      return should(webIds).have.length(3);
     });
   });
 

--- a/test/experimental_apis/web_id.js
+++ b/test/experimental_apis/web_id.js
@@ -106,6 +106,46 @@ describe('Experimental WebID emulation', () => {
     return should(serialised.length).be.above(0);
   });
 
+  it('retrieving WebID object from URI as Turtle', async () => {
+    const randomName = `test_${Math.round(Math.random() * 100000)}`;
+    const profile = {
+      uri: `safe://mywebid.${randomName}`,
+      name: randomName,
+      nick: randomName,
+      website: `safe://mywebsite.${randomName}`,
+      image: `safe://mywebsite.${randomName}/images/myavatar`,
+    };
+
+    const webId = md.emulateAs('WebID');
+    await webId.create(profile);
+    const serialised = await webId.serialise('text/turtle');
+
+    // Turtle is the default format for RDFs returned by webFetch
+    const webIdResponse = await app.webFetch(profile.uri);
+    should(webIdResponse.headers['Content-Type']).be.equal('text/turtle');
+    return should(serialised).be.equal(webIdResponse.body);
+  });
+
+  it('retrieving WebID object from URI as JSON-LD', async () => {
+    const randomName = `test_${Math.round(Math.random() * 100000)}`;
+    const profile = {
+      uri: `safe://mywebid.${randomName}`,
+      name: randomName,
+      nick: randomName,
+      website: `safe://mywebsite.${randomName}`,
+      image: `safe://mywebsite.${randomName}/images/myavatar`,
+    };
+
+    const webId = md.emulateAs('WebID');
+    await webId.create(profile);
+
+    const options = { accept: 'application/ld+json' };
+    const serialised = await webId.serialise(options.accept);
+    const webIdResponse = await app.webFetch(profile.uri, options);
+    should(webIdResponse.headers['Content-Type']).be.equal(options.accept);
+    return should(serialised).be.equal(webIdResponse.body);
+  });
+
   it('verify _publicNames is populated for creating several WebIDs', async () => {
     const numOfWebIds = 3;
     const pubNamesApp = await h.publicNamesTestApp();

--- a/test/experimental_apis/xor_urls.js
+++ b/test/experimental_apis/xor_urls.js
@@ -1,0 +1,217 @@
+// Copyright 2018 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under
+// the MIT license <LICENSE-MIT or http://opensource.org/licenses/MIT> or
+// the Modified BSD license <LICENSE-BSD or https://opensource.org/licenses/BSD-3-Clause>,
+// at your option.
+//
+// This file may not be copied, modified, or distributed except according to those terms.
+//
+// Please review the Licences for the specific language governing permissions and limitations
+// relating to use of the SAFE Network Software.
+
+
+const should = require('should');
+const helpers = require('../helpers');
+const errConst = require('../../src/error_const');
+
+const containersPermissions = {
+  _public: ['Read'],
+  _publicNames: ['Read', 'Insert', 'ManagePermissions']
+};
+
+const createAuthenticatedTestApp = helpers.createAuthenticatedTestApp;
+const createUnregisteredTestApp = helpers.createUnregisteredTestApp;
+const createDomain = helpers.createDomain;
+const createRandomDomain = helpers.createRandomDomain;
+const expApisOpts = { enableExperimentalApis: true };
+
+const decomposeXorUrl = (xorUrl) => {
+  const parts = xorUrl.replace(/^safe:\/\//).split(':');
+  return { cid: parts[0], typeTag: parts[1] };
+};
+
+describe('WebFetch with XOR URL', () => {
+  const TYPE_TAG = 41000;
+  let app;
+  let unregisteredApp;
+
+  before(async () => {
+    app = await createAuthenticatedTestApp('_test_scope', containersPermissions,
+                                            null, expApisOpts);
+    unregisteredApp = await createUnregisteredTestApp(expApisOpts);
+  });
+
+  it('fail to fetch with XOR-URL if experimental apis flag is not set', async () => {
+    let error;
+    try {
+      const content = `hello world, on ${Math.round(Math.random() * 100000)}`;
+      const { serviceMd } = await createRandomDomain(content, 'index.html', '', app);
+      const info = await serviceMd.getNameAndTag();
+      should(info.xorUrl).not.be.undefined();
+      const safeApp = await createUnregisteredTestApp({ enableExperimentalApis: false });
+      await safeApp.webFetch(info.xorUrl);
+    } catch (err) {
+      error = err;
+    }
+    return should(error.message).equal(errConst.ERR_CONTENT_NOT_FOUND.msg);
+  });
+
+  it('undefined XOR-URL from MD if experimental apis flag is not set', async () => {
+    const safeApp = await createUnregisteredTestApp({ enableExperimentalApis: false });
+    const md = await safeApp.mutableData.newRandomPublic(TYPE_TAG);
+    await md.quickSetup();
+    const info = await md.getNameAndTag();
+    return should(info.xorUrl).be.undefined();
+  });
+
+  it('fail to get XOR-URL from IMD if experimental apis flag is not set', async () => {
+    let error;
+    const safeApp = await createUnregisteredTestApp({ enableExperimentalApis: false });
+    try {
+      const content = `hello world, on ${Math.round(Math.random() * 100000)}`;
+      const idWriter = await safeApp.immutableData.create();
+      await idWriter.write(content);
+      const cipherOpt = await safeApp.cipherOpt.newPlainText();
+      const getXorUrl = true;
+      await idWriter.close(cipherOpt, getXorUrl);
+    } catch (err) {
+      error = err;
+    }
+    return should(error.message).equal(errConst.EXPERIMENTAL_API_DISABLED.msg('XOR URLs'));
+  });
+
+  it('valid MD XOR-URL for non existing content, rejected', async () =>
+    should(unregisteredApp.webFetch('safe://zb2rhe5P4gXftAwvA4eXQ5HJwsER2owDyS9sKaQRRVQPn93bA:15000')).be.rejectedWith(errConst.ERR_CONTENT_NOT_FOUND.msg)
+  );
+
+  it('valid ImmD XOR-URL for non existing content, rejected', async () =>
+    should(unregisteredApp.webFetch('safe://zb2rhe5P4gXftAwvA4eXQ5HJwsER2owDyS9sKaQRRVQPn93bA')).be.rejectedWith(errConst.ERR_CONTENT_NOT_FOUND.msg)
+  );
+
+  it('invalid ImmD XOR-URL should default to public name lookup, rejected', async () =>
+    should(unregisteredApp.webFetch('safe://xb2rhe5P4gXftAwvA4eXQ5HJwsER2owDyS9sKaQRRVQPn93bA')).be.rejectedWith(errConst.ERR_CONTENT_NOT_FOUND.msg)
+  );
+
+  it('invalid MD XOR-URL, rejected', async () =>
+    should(unregisteredApp.webFetch('safe://xb2rhe5P4gXftAwvA4eXQ5HJwsER2owDyS9sKaQRRVQPn93bA:15000')).be.rejectedWith(errConst.ERR_CONTENT_NOT_FOUND.msg)
+  );
+
+  it('valid MD XOR-URL but invalid type tag, rejected', async () => {
+    const md = await app.mutableData.newRandomPublic(TYPE_TAG);
+    await md.quickSetup();
+    const info = await md.getNameAndTag();
+    const xorUrlParts = decomposeXorUrl(info.xorUrl);
+    const fetchCall = unregisteredApp.webFetch(`safe://${xorUrlParts.cid}:${xorUrlParts.typeTag + 1}`);
+    return should(fetchCall).be.rejectedWith(errConst.ERR_CONTENT_NOT_FOUND.msg);
+  });
+
+  it('valid MD XOR-URL same as published public name, invalid type tag, rejected', async () => {
+    const md = await app.mutableData.newRandomPublic(TYPE_TAG);
+    await md.quickSetup();
+    const info = await md.getNameAndTag();
+    should(info.xorUrl).not.be.undefined();
+    const xorUrlParts = decomposeXorUrl(info.xorUrl);
+    const content = `hello world, on ${Math.round(Math.random() * 100000)}`;
+    await createDomain(xorUrlParts.cid, content, '', '');
+    const fetchCall = unregisteredApp.webFetch(`safe://${xorUrlParts.cid}:${xorUrlParts.typeTag + 1}`);
+    return should(fetchCall).be.rejectedWith(errConst.ERR_CONTENT_NOT_FOUND.msg);
+  });
+
+  it('valid MD XOR-URL and type tag on NFS container', async () => {
+    const content = `hello world, on ${Math.round(Math.random() * 100000)}`;
+    const { serviceMd } = await createRandomDomain(content, 'index.html', '', app);
+    const info = await serviceMd.getNameAndTag();
+    const data = await unregisteredApp.webFetch(info.xorUrl);
+    return should(data.body.toString()).equal(content);
+  });
+
+  it('valid MD XOR-URL and type tag on NFS container, invalid path, rejected', async () => {
+    const content = `hello world, on ${Math.round(Math.random() * 100000)}`;
+    const { serviceMd } = await createRandomDomain(content, '/index.html', '', app);
+    const info = await serviceMd.getNameAndTag();
+    should(info.xorUrl).not.be.undefined();
+    const fetchCall = unregisteredApp.webFetch(`${info.xorUrl}/invalid-folder`);
+    return should(fetchCall).be.rejectedWith(errConst.ERR_FILE_NOT_FOUND.msg);
+  });
+
+  it('valid MD XOR-URL and type tag on NFS container with path', async () => {
+    const content = `hello world, on ${Math.round(Math.random() * 100000)}`;
+    const { serviceMd } = await createRandomDomain(content, '/folder/index.html', '', app);
+    const info = await serviceMd.getNameAndTag();
+    should(info.xorUrl).not.be.undefined();
+    const data = await unregisteredApp.webFetch(`${info.xorUrl}/folder`);
+    return should(data.body.toString()).equal(content);
+  });
+
+  it('returns a MD explorer html page when no index.html found', async () => {
+    const md = await app.mutableData.newRandomPublic(TYPE_TAG);
+    await md.quickSetup({ key1: 'value' });
+    const info = await md.getNameAndTag();
+    const data = await unregisteredApp.webFetch(`${info.xorUrl.toUpperCase()}`);
+    return should(data.headers).eql({ 'Content-Type': 'text/html' });
+  });
+
+  it('does not return a MD explorer if experimental apis is disabled', async () => {
+    const content = `hello world, on ${Math.round(Math.random() * 100000)}`;
+    const { domain } = await createRandomDomain(content, '/noindex.html', '', app);
+    const safeApp = await createUnregisteredTestApp({ enableExperimentalApis: false });
+    return should(safeApp.webFetch(`safe://${domain}`)).be.rejectedWith(errConst.ERR_FILE_NOT_FOUND.msg);
+  });
+
+  it('valid MD XOR-URL and type tag on non-NFS container with empty path', async () => {
+    const md = await app.mutableData.newRandomPublic(TYPE_TAG);
+    await md.quickSetup({ key1: 'value' });
+    const info = await md.getNameAndTag();
+    const data = await unregisteredApp.webFetch(`${info.xorUrl.toUpperCase()}/`);
+    // it should return the mutableData viewer/explorer
+    return should(data.headers).eql({ 'Content-Type': 'text/html' });
+  });
+
+  it('valid ImmD XOR-URL', async () => {
+    const content = `hello world, on ${Math.round(Math.random() * 100000)}`;
+    const idWriter = await app.immutableData.create();
+    await idWriter.write(content);
+    const cipherOpt = await app.cipherOpt.newPlainText();
+    const getXorUrl = true;
+    const immDataAddr = await idWriter.close(cipherOpt, getXorUrl);
+    should(immDataAddr.xorUrl).not.be.undefined();
+    const data = await unregisteredApp.webFetch(immDataAddr.xorUrl);
+    should(data.body.toString()).equal(content);
+    should(data.headers).eql({ 'Content-Type': 'application/octet-stream' });
+  });
+
+  it('valid ImmD XOR-URL with invalid codec code, rejected', async () => {
+    const content = `hello world, on ${Math.round(Math.random() * 100000)}`;
+    const idWriter = await app.immutableData.create();
+    await idWriter.write(content);
+    const cipherOpt = await app.cipherOpt.newPlainText();
+    const getXorUrl = true;
+    const closeCall = idWriter.close(cipherOpt, getXorUrl, 'invalid-codec');
+    return should(closeCall).be.rejectedWith('Codec `mime/invalid-codec` not found');
+  });
+
+  it('valid ImmD XOR-URL with valid codec code', async () => {
+    const content = `hello world, on ${Math.round(Math.random() * 100000)}`;
+    const idWriter = await app.immutableData.create();
+    await idWriter.write(content);
+    const cipherOpt = await app.cipherOpt.newPlainText();
+    const getXorUrl = true;
+    const immDataAddr = await idWriter.close(cipherOpt, getXorUrl, 'image/png');
+    const data = await unregisteredApp.webFetch(immDataAddr.xorUrl);
+    should(data.body.toString()).equal(content);
+    should(data.headers).eql({ 'Content-Type': 'image/png' });
+  });
+
+  it('valid ImmD XOR-URL equal to a published public name', async () => {
+    const md = await app.mutableData.newRandomPublic(41000);
+    await md.quickSetup();
+    const info = await md.getNameAndTag();
+    should(info.xorUrl).not.be.undefined();
+    const { cid } = decomposeXorUrl(info.xorUrl);
+    const content = `hello world, on ${Math.round(Math.random() * 100000)}`;
+    await createDomain(cid, content, '', '');
+    const data = await unregisteredApp.webFetch(`safe://${cid}`);
+    should(data.body.toString()).equal(content);
+  });
+});

--- a/test/experimental_apis/xor_urls.js
+++ b/test/experimental_apis/xor_urls.js
@@ -152,6 +152,17 @@ describe('WebFetch with XOR URL', () => {
     return should(data.headers).eql({ 'Content-Type': 'text/html' });
   });
 
+  it('returns a MD explorer html even after removing entries from MD', async () => {
+    const md = await app.mutableData.newRandomPublic(TYPE_TAG);
+    await md.quickSetup({ key1: 'value' });
+    const mut = await app.mutableData.newMutation();
+    await mut.delete('key1', 1);
+    await md.applyEntriesMutation(mut);
+    const info = await md.getNameAndTag();
+    const data = await unregisteredApp.webFetch(`${info.xorUrl.toUpperCase()}`);
+    return should(data.headers).eql({ 'Content-Type': 'text/html' });
+  });
+
   it('does not return a MD explorer if experimental apis is disabled', async () => {
     const content = `hello world, on ${Math.round(Math.random() * 100000)}`;
     const { domain } = await createRandomDomain(content, '/noindex.html', '', app);

--- a/test/experimental_apis/xor_urls.js
+++ b/test/experimental_apis/xor_urls.js
@@ -14,6 +14,7 @@
 const should = require('should');
 const helpers = require('../helpers');
 const errConst = require('../../src/error_const');
+const { escapeHtmlEntities } = require('../../src/helpers');
 
 const containersPermissions = {
   _public: ['Read'],
@@ -161,6 +162,13 @@ describe('WebFetch with XOR URL', () => {
     const info = await md.getNameAndTag();
     const data = await unregisteredApp.webFetch(`${info.xorUrl.toUpperCase()}`);
     return should(data.headers).eql({ 'Content-Type': 'text/html' });
+  });
+
+  it('helper function escapeHtmlEntities', () => {
+    const html = '<script>script-injection</script>"safe://xorurl:15000/folder#fragment?arg1=44&arg2=56"';
+    const escapedHtml = '&lt;script&gt;script-injection&lt;&#x2F;script&gt;&quot;safe:&#x2F;&#x2F;xorurl:15000&#x2F;folder#fragment?arg1=44&amp;arg2=56&quot;';
+    const text = escapeHtmlEntities(html);
+    return should(text).be.equal(escapedHtml);
   });
 
   it('does not return a MD explorer if experimental apis is disabled', async () => {

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -124,6 +124,7 @@ module.exports = {
   createRandomInvalidSecKey,
   createRandomInvalidXor,
   createRandomInvalidNonce,
+  createDomain,
   createRandomDomain,
   createRandomPrivateServiceDomain,
   publicNamesTestApp

--- a/yarn.lock
+++ b/yarn.lock
@@ -977,6 +977,18 @@ balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
 
+base-x@3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/base-x/-/base-x-3.0.4.tgz#94c1788736da065edb1d68808869e357c977fa77"
+  dependencies:
+    safe-buffer "^5.0.1"
+
+base-x@^3.0.2:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/base-x/-/base-x-3.0.5.tgz#d3ada59afed05b921ab581ec3112e6444ba0795a"
+  dependencies:
+    safe-buffer "^5.0.1"
+
 base64url@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/base64url/-/base64url-3.0.0.tgz#f2ba30b15f80413d88e3e6116c4f3f7f61e28a2a"
@@ -1084,6 +1096,12 @@ browserslist@^3.2.6:
     caniuse-lite "^1.0.30000844"
     electron-to-chromium "^1.3.47"
 
+bs58@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/bs58/-/bs58-4.0.1.tgz#be161e76c354f6f788ae4071f63f34e8c4f0a42a"
+  dependencies:
+    base-x "^3.0.2"
+
 buffer-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/buffer-equal/-/buffer-equal-1.0.0.tgz#59616b498304d556abd466966b22eeda3eca5fbe"
@@ -1142,7 +1160,7 @@ caller-path@^0.1.0:
 
 callsites@^0.2.0:
   version "0.2.0"
-  resolved "https://registry.yarnpkg.com/callsites/-/callsites-0.2.0.tgz#afab96262910a7f33c19a5775825c69f34e350ca"
+  resolved "http://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz#afab96262910a7f33c19a5775825c69f34e350ca"
 
 camelcase-keys@^2.0.0:
   version "2.1.0"
@@ -1160,8 +1178,8 @@ camelcase@^4.1.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
 
 caniuse-lite@^1.0.30000844:
-  version "1.0.30000909"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000909.tgz#697e8f447ca5f758e7c6cef39ec429ce18b908d3"
+  version "1.0.30000910"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000910.tgz#755d5181d4b006e5a2b59b1ffa05d0a0470039f5"
 
 caseless@~0.11.0:
   version "0.11.0"
@@ -1262,6 +1280,14 @@ chownr@^1.1.1:
 ci-info@^1.5.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.6.0.tgz#2ca20dbb9ceb32d4524a683303313f0304b1e497"
+
+cids@bochaco/js-cid#temp-use-bochaco-multicodec:
+  version "0.5.3"
+  resolved "https://codeload.github.com/bochaco/js-cid/tar.gz/fdd908ad57edd5359008adffde1ce32e3e970b15"
+  dependencies:
+    multibase "~0.4.0"
+    multicodec bochaco/js-multicodec#mime-types-as-codecs
+    multihashes "~0.4.13"
 
 circular-json@^0.3.1:
   version "0.3.3"
@@ -3368,11 +3394,11 @@ lowercase-keys@^1.0.0:
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz#6f9e30b47084d971a7c820ff15a6c5167b74c26f"
 
 lru-cache@^4.0.1:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.3.tgz#a1175cf3496dfc8436c156c334b4955992bce69c"
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.4.tgz#51cc46e8e6d9530771c857e24ccc720ecdbcc031"
   dependencies:
     pseudomap "^1.0.2"
-    yallist "^2.1.2"
+    yallist "^3.0.2"
 
 map-cache@^0.2.0, map-cache@^0.2.2:
   version "0.2.2"
@@ -3640,6 +3666,25 @@ ms@2.0.0:
 ms@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
+
+multibase@~0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/multibase/-/multibase-0.4.0.tgz#1bdb62c82de0114f822a1d8751bcbee91cd2efba"
+  dependencies:
+    base-x "3.0.4"
+
+multicodec@bochaco/js-multicodec#mime-types-as-codecs:
+  version "0.2.7"
+  resolved "https://codeload.github.com/bochaco/js-multicodec/tar.gz/71f81e833bb35776d21f4c1f6e6427379055c264"
+  dependencies:
+    varint "^5.0.0"
+
+multihashes@^0.4.14, multihashes@~0.4.13:
+  version "0.4.14"
+  resolved "https://registry.yarnpkg.com/multihashes/-/multihashes-0.4.14.tgz#774db9a161f81a8a27dc60788f91248e020f5244"
+  dependencies:
+    bs58 "^4.0.1"
+    varint "^5.0.0"
 
 mute-stream@0.0.5:
   version "0.0.5"
@@ -3998,7 +4043,7 @@ parse-filepath@^1.0.2:
 
 parse-git-config@^0.2.0:
   version "0.2.0"
-  resolved "https://registry.yarnpkg.com/parse-git-config/-/parse-git-config-0.2.0.tgz#272833fdd15fea146fb75d336d236b963b6ff706"
+  resolved "http://registry.npmjs.org/parse-git-config/-/parse-git-config-0.2.0.tgz#272833fdd15fea146fb75d336d236b963b6ff706"
   dependencies:
     ini "^1.3.3"
 
@@ -4507,8 +4552,8 @@ remark-parse@^5.0.0:
     xtend "^4.0.1"
 
 remark-reference-links@^4.0.1:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/remark-reference-links/-/remark-reference-links-4.0.2.tgz#817c63486901bd4f5f8a0cf48a695f5ecd2c966d"
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/remark-reference-links/-/remark-reference-links-4.0.3.tgz#eb51ad4fddb009199f98ac403d0558d732e2df89"
   dependencies:
     unist-util-visit "^1.0.0"
 
@@ -4899,8 +4944,8 @@ sntp@1.x.x:
     hoek "2.x.x"
 
 solid-auth-client@^2.2.3:
-  version "2.2.12"
-  resolved "https://registry.yarnpkg.com/solid-auth-client/-/solid-auth-client-2.2.12.tgz#0e479b3a58a9c0370026edf19a855281b47077c7"
+  version "2.2.13"
+  resolved "https://registry.yarnpkg.com/solid-auth-client/-/solid-auth-client-2.2.13.tgz#ecc9fc1c1f6b315c96b2a728609089b677388253"
   dependencies:
     "@babel/runtime" "^7.0.0"
     "@solid/oidc-rp" "^0.8.0"
@@ -5537,6 +5582,10 @@ value-or-function@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/value-or-function/-/value-or-function-3.0.0.tgz#1c243a50b595c1be54a754bfece8563b9ff8d813"
 
+varint@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/varint/-/varint-5.0.0.tgz#d826b89f7490732fabc0c0ed693ed475dcb29ebf"
+
 verror@1.10.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/verror/-/verror-1.10.0.tgz#3a105ca17053af55d6e270c1f8288682e18da400"
@@ -5546,12 +5595,12 @@ verror@1.10.0:
     extsprintf "^1.2.0"
 
 vfile-location@^2.0.0:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/vfile-location/-/vfile-location-2.0.3.tgz#083ba80e50968e8d420be49dd1ea9a992131df77"
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/vfile-location/-/vfile-location-2.0.4.tgz#2a5e7297dd0d9e2da4381464d04acc6b834d3e55"
 
 vfile-message@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/vfile-message/-/vfile-message-1.0.1.tgz#51a2ccd8a6b97a7980bb34efb9ebde9632e93677"
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/vfile-message/-/vfile-message-1.0.2.tgz#0f8a62584c5dff0f81760531b8e34f3cea554ebc"
   dependencies:
     unist-util-stringify-position "^1.1.1"
 
@@ -5566,12 +5615,12 @@ vfile-reporter@^4.0.0:
     vfile-statistics "^1.1.0"
 
 vfile-sort@^2.1.0:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/vfile-sort/-/vfile-sort-2.1.2.tgz#99aa1b644149f0e0114661af94bd514d2be7d466"
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/vfile-sort/-/vfile-sort-2.1.3.tgz#2e114ab8aec2aaa71300dcc548b28d1ef9606363"
 
 vfile-statistics@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/vfile-statistics/-/vfile-statistics-1.1.1.tgz#a22fd4eb844c9eaddd781ad3b3246db88375e2e3"
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/vfile-statistics/-/vfile-statistics-1.1.2.tgz#c50132627e4669a3afa07c64ff1e7aa7695e8151"
 
 vfile@^2.0.0, vfile@^2.3.0:
   version "2.3.0"
@@ -5731,10 +5780,6 @@ xtend@~2.1.1:
 y18n@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41"
-
-yallist@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
 
 yallist@^3.0.0, yallist@^3.0.2:
   version "3.0.2"


### PR DESCRIPTION
Resolves #304 

Exposing the xor-url functionality all behind the `--enableExperimentalApis` flag, either for the functions which generate the XOR-URLs for ImmutableData and MutableData objects, as well as for the `webFetch` support to resolve such URLs.