### PR TITLE
fix(Experiments): Web API exposure now throws per func

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -42,7 +42,10 @@ const isExperimentalApisEnabled = process.argv.includes('--enable-experimental-a
 // Helper function to check the experimental APIs flag and
 // either throw an error or log a warning message
 function checkExperimentalApisFlag(fn) {
-  const featureName = fn.name.replace('_', ' ');
+  const featureName = fn.name.replace('_', ' ')
+                        // bound added when binding context
+                        .replace('bound ', '');
+
   // the experimental APIs can be also enabled by setting
   // the `enableExperimentalApis` flag can be set to true in the initialisation options.
   if (!isExperimentalApisEnabled && !this.options.enableExperimentalApis) {
@@ -75,9 +78,9 @@ function checkExperimentalApisFlag(fn) {
      });
  * }
 */
-function EXPOSE_AS_EXPERIMENTAL_API(fn) {
+function EXPOSE_AS_EXPERIMENTAL_API(fn, ...args) {
   checkExperimentalApisFlag.call(this, fn);
-  return fn.call(this);
+  return fn.call(this, ...args);
 }
 
 /* Helper to be used by experimental features which shouldn't

--- a/src/native/_error.js
+++ b/src/native/_error.js
@@ -1,11 +1,11 @@
 // Copyright 2018 MaidSafe.net limited.
 //
-// This SAFE Network Software is licensed to you under 
-// the MIT license <LICENSE-MIT or http://opensource.org/licenses/MIT> or 
+// This SAFE Network Software is licensed to you under
+// the MIT license <LICENSE-MIT or http://opensource.org/licenses/MIT> or
 // the Modified BSD license <LICENSE-BSD or https://opensource.org/licenses/BSD-3-Clause>,
 // at your option.
 //
-// This file may not be copied, modified, or distributed except according to those terms. 
+// This file may not be copied, modified, or distributed except according to those terms.
 //
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.

--- a/test/experimental_apis/web.js
+++ b/test/experimental_apis/web.js
@@ -44,7 +44,7 @@ describe('Experimental Web API', () => {
       } catch (err) {
         error = err;
       }
-      return should(error.message).equal(errConst.EXPERIMENTAL_API_DISABLED.msg('Web API'));
+      return should(error.message).equal(errConst.EXPERIMENTAL_API_DISABLED.msg('getPublicNames'));
     });
 
     it('should throw when app perms are not given for _publicNames', async () => {


### PR DESCRIPTION
## Currently

The web API throws an experimental error (erroneously) when attempting to access `safeapp.web` on an instantiated safe app (when experiments are disabled).

## Wanted

safe_app should throw experimental errors when attempting to use exposed `web` functionality, (ie: `safeapp.web.getVocabs()` should throw an experimental error as opposed to attempting to access `safeapp.web`, which should not throw).

