### PR TITLE
fix/fetch: when fetching a MD the `resourceType` value was 'NFS' instead of 'MD'

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,5 +1,15 @@
 # safe_app nodejs Change Log
 
+## [Unreleased]
+
+### Fixed
+- Experimental function `fetch` was not returning value `MD` in `resourceType` when fetching a MutableData
+
+### SAFE libraries Dependencies
+- safe_app: v0.9.0
+- system_uri: v0.4.0
+- deps_downloader: v0.3.0
+
 ## [0.10.0] - 26-11-2018
 ### Added
 - Add instructions to the README for how to generate API docs locally

--- a/src/web_fetch.js
+++ b/src/web_fetch.js
@@ -266,11 +266,9 @@ async function fetchHelper(url) {
         const content = await getContainerFromCid.call(this, publicName,
                                                         parseInt(parsedUrl.port, 10));
 
-        const resourceType = (content.type === DATA_TYPE_MD) ? DATA_TYPE_NFS : content.type;
-
         return {
           content: content.content,
-          resourceType,
+          resourceType: content.type,
           parsedPath,
           mimeType: content.codec
         };
@@ -486,7 +484,7 @@ async function webFetch(url, options) {
   }
   const path = tokens.join('/') || `/${consts.INDEX_HTML}`;
   try {
-    const emulation = content.emulateAs(resourceType);
+    const emulation = content.emulateAs(DATA_TYPE_NFS);
     const { file, mimeType: fileMimeType } = await
                             tryDifferentPaths(emulation.fetch.bind(emulation), path);
     const openedFile = await emulation.open(file, consts.pubConsts.NFS_FILE_MODE_READ);

--- a/test/experimental_apis/rdf.js
+++ b/test/experimental_apis/rdf.js
@@ -122,6 +122,8 @@ describe('Experimental RDF emulation', () => {
     return should(rdf.parse({}, JSON_LD_MIME_TYPE, myUri)).be.rejected();
   });
 
+  it('generate a blank node', async () => should(rdf.bnode).be.not.undefined());
+
   it('add triples and find any friend', async () => {
     await md.quickSetup({});
     await rdf.parse(JSON.stringify(myJsonLd), JSON_LD_MIME_TYPE, myUri);


### PR DESCRIPTION
When calling the `fetch` experimental API to fetch a MD the value returned in the resourceType was 'NFS' instead of 'MD'. I'm also adding some tests for fetching different type of resources, i.e. MD, IMMD, RDF and NFS.