### PR TITLE
fix/addPublicNameToDirectory: add publicName when the _publicNames has entries in old/non-RDF format

### DIFF
--- a/src/api/emulations/rdf.js
+++ b/src/api/emulations/rdf.js
@@ -114,7 +114,11 @@ class RDF {
     }, Promise.resolve([]));
 
     const entriesGraphs = await Promise.all(validGraphs);
+
     if (!id) {
+      // This simply means that none of the existing entries are RDF graphs.
+      // We throw the error and it's up to the caller to decide
+      // what to do in such an scenario
       throw makeError(errConst.MISSING_RDF_ID.code, errConst.MISSING_RDF_ID.msg);
     }
 

--- a/test/experimental_apis/web.js
+++ b/test/experimental_apis/web.js
@@ -130,14 +130,15 @@ describe('Experimental Web API', () => {
     });
 
     it('should add publicName even on top of container old data format', async () => {
-      const pubNamesCont = await authedApp.auth.getContainer('_publicNames');
-      const mut = await authedApp.mutableData.newMutation();
+      const newAuthedApp = await h.publicNamesTestApp();
+      const pubNamesCont = await newAuthedApp.auth.getContainer('_publicNames');
+      const mut = await newAuthedApp.mutableData.newMutation();
       const encKey = await pubNamesCont.encryptKey('key');
       const encValue = await pubNamesCont.encryptValue('value');
       await mut.insert(encKey, encValue);
       await pubNamesCont.applyEntriesMutation(mut);
-      await authedApp.web.addPublicNameToDirectory('thisIsATestDomain', fakeSubdomainRDF);
-      const publicNames = await authedApp.web.getPublicNames();
+      await newAuthedApp.web.addPublicNameToDirectory('thisIsATestDomain', fakeSubdomainRDF);
+      const publicNames = await newAuthedApp.web.getPublicNames();
       should(publicNames).be.a.Array();
       return should(publicNames).containDeep(['safe://_publicNames#thisIsATestDomain']);
     });


### PR DESCRIPTION
If the account has some entries in the `_publicNames` default container which are not RDF graphs, calling the experimental `addPublicNameToDirectory` function throws an error and the publicName is not added to the `_publicNames` container as expected.