### PR TITLE
fix/RDF: ignore any entry which cannot be decrypted when reading an emulated Private MD

### DIFF
--- a/src/api/emulations/rdf.js
+++ b/src/api/emulations/rdf.js
@@ -79,7 +79,7 @@ class RDF {
       const reducedGraphs = await graphs;
       let keyStr = entry.key.toString();
       let valueStr = entry.value.buf.toString();
-      if (toDecrypt) {
+      if (toDecrypt && valueStr.length > 0) {
         try {
           const decryptedKey = await this.mData.decrypt(entry.key);
           keyStr = decryptedKey.toString();

--- a/src/api/emulations/rdf.js
+++ b/src/api/emulations/rdf.js
@@ -87,8 +87,7 @@ class RDF {
           valueStr = decryptedValue.toString();
         } catch (error) {
           if (error.code !== errConst.ERR_SERIALISING_DESERIALISING.code) {
-            console.error('Error decrypting MutableData entry in rdf.nowOrWhenFetched()');
-            throw error;
+            console.warn('Error decrypting MutableData entry in rdf.nowOrWhenFetched()');
           }
           // ok, let's then assume the entry is not encrypted
           // this maybe temporary, just for backward compatibility,
@@ -230,7 +229,7 @@ class RDF {
             keyToCheck = decryptedKey.toString();
           } catch (error) {
             if (error.code !== errConst.ERR_SERIALISING_DESERIALISING.code) {
-              console.error('Error decrypting MutableData entry in rdf.commit():', error);
+              console.warn('Error decrypting MutableData entry in rdf.commit():', error);
             }
             // ok, let's then assume the entry is not encrypted
             // this maybe temporary, just for backward compatibility,
@@ -269,7 +268,7 @@ class RDF {
             keyToCheck = decryptedKey.toString();
           } catch (error) {
             if (error.code !== errConst.ERR_SERIALISING_DESERIALISING.code) {
-              console.error('Error decrypting MutableData entry in rdf.commit():', error);
+              console.warn('Error decrypting MutableData entry in rdf.commit():', error);
             }
             // ok, let's then assume the entry is not encrypted
             // this maybe temporary, just for backward compatibility,

--- a/test/experimental_apis/rdf.js
+++ b/test/experimental_apis/rdf.js
@@ -356,6 +356,7 @@ describe('Experimental RDF emulation', () => {
                                                 h.createRandomSecKey(),
                                                 h.createRandomNonce());
     const notMyRdf = notMyMd.emulateAs('rdf');
-    return should(notMyRdf.nowOrWhenFetched(null, encrypted)).be.rejectedWith('Core error: Symmetric decryption failed');
+    return should(notMyRdf.nowOrWhenFetched(null, encrypted))
+                                  .be.rejectedWith(errConst.MISSING_RDF_ID.msg);
   });
 });


### PR DESCRIPTION
When fetching the entries of the RDF emulated private MD, when an entry cannot be decrypted we are throwing an error but we can simply ignore such an entry and not use it to reconstruct the RDF graph/document, just log warning message.

Also, as a consecuence of the app revocation process, after revoking an app any entry it created in the `_publicNames` container has to be re-encrypted. The new encrypted entry's key string is different form the previous one (since a new encryption key is used), so the revocation process is removing the old one (soft-delete), and inserting the newly encrypted one. 
After re-authorising any other app, the new encryption key is obtained to decrypt the entries, but the old entry was soft-deleted and its key cannot be decrypted anymore as it was encrypted with previous encryption key. The new ones can be decrypted without issues by the other app/s after re-authorising themselves. We therefore should also simply not try to decrypt a key if the entry was soft-deleted (empty value).

This solves the issue seen in here: https://github.com/maidsafe/safe_browser/issues/470