### PR TITLE
chore/deps: upgrades FFI to master branch of repository

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -10,6 +10,7 @@
 ### Changed
 - All RDF methods which take RDF `subject`, `predicate`, `object` arguments now also take a fourth `provenance` argument, to be consistent with rdflib.js
 - Documentation enhanced with improved JSDoc annotation and template
+- Upgrade Node-FFI to depend on master branch of repository
 
 ### Added
 - Code examples for experimental API operations: RDF, WebId, WebInterface

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "cross-env": "5.1.3",
     "deps_downloader": "https://s3.eu-west-2.amazonaws.com/deps-downloader/deps_downloader-0.3.0.tgz",
     "enum": "^2.3.0",
-    "ffi": "^2.2.0",
+    "ffi": "https://github.com/node-ffi/node-ffi.git",
     "mime": "^2.0.3",
     "multihashes": "^0.4.14",
     "rdflib": "^0.19.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -309,6 +309,7 @@ bindings@1, bindings@^1.2.1:
 bindings@~1.2.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.2.1.tgz#14ad6113812d2d37d72e67b4cacb4bb726505f11"
+  integrity sha1-FK1hE4EtLTfXLme0ystLtyZQXxE=
 
 bluebird@~3.5.0:
   version "3.5.3"
@@ -890,9 +891,9 @@ fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
 
-ffi@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/ffi/-/ffi-2.2.0.tgz#bf18b04666a29f71227ed56895d5430af47042fa"
+"ffi@https://github.com/node-ffi/node-ffi.git":
+  version "2.3.0"
+  resolved "https://github.com/node-ffi/node-ffi.git#04ec7771c9ed64a34762533819e08c7decaa633d"
   dependencies:
     bindings "~1.2.0"
     debug "2"


### PR DESCRIPTION
The purpose of this is to be able to upgrade to Electron v4.0.0 in SAFE Browser